### PR TITLE
Note about development packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Check out the wiki [http://github.com/polotek/libxmljs/wiki](http://github.com/p
 
 ## Requirements
 
-* [libxml2](http://www.xmlsoft.org/)
+* [libxml2](http://www.xmlsoft.org/) (and development packages)
 * [node.js](http://nodejs.org/)
 * v8 (comes bundled with node, no need to install)
 * [scons](http://www.scons.org/) (for building)


### PR DESCRIPTION
I added a note about development packages to the README.md. To build libxmljs on Ubuntu 10.04, I had to install scons and libxml2-dev (libxml2 was already installed by default).
