### PR TITLE
use CPPPATH from environment if it exists

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -57,6 +57,9 @@ env.Append(
   CCFLAGS = cflags
 )
 
+if 'CPPPATH' in os.environ:
+  env.Append(CPPPATH = os.environ['CPPPATH'])
+
 if not env.GetOption('clean'):
   conf = Configure(env, custom_tests = {'CheckForNodeJS' : CheckForNodeJS})
   print conf.CheckForNodeJS()


### PR DESCRIPTION
This will pull in CPPPATH from the environment to specify an alternate location for header files.
