### PR TITLE
enables memory debugging only when you compile libxmljs to do so

### DIFF
--- a/src/libxmljs.cc
+++ b/src/libxmljs.cc
@@ -157,8 +157,10 @@ void
 InitializeLibXMLJS(v8::Handle<v8::Object> target) {
   v8::HandleScope scope;
 
+#ifdef DEBUG
   xmlMemSetup(xmlMemFree, xmlMemMalloc, xmlMemRealloc, xmlMemoryStrdup);
   xmlInitMemory();
+#endif
 
   XmlSyntaxError::Initialize(target);
   XmlDocument::Initialize(target);


### PR DESCRIPTION
Hey Polotek, 

I did a little change to enable memory debugging if you compile the library with make node-debug. Hopefully this would close the issue #13
