### PR TITLE
enables memory debugging if the libxmljs is compiled to do so.

### DIFF
--- a/src/libxmljs.cc
+++ b/src/libxmljs.cc
@@ -157,8 +157,10 @@ void
 InitializeLibXMLJS(v8::Handle<v8::Object> target) {
   v8::HandleScope scope;
 
+#ifdef DEBUG_MEMORY
   xmlMemSetup(xmlMemFree, xmlMemMalloc, xmlMemRealloc, xmlMemoryStrdup);
   xmlInitMemory();
+#endif
 
   XmlSyntaxError::Initialize(target);
   XmlDocument::Initialize(target);


### PR DESCRIPTION
Hi polotek 

I just did a little change to get rid of the memory messages, it will show them only when people compile libxmljs using make node-debug. Hopefully this would close #13. 
