### PR TITLE
64-bit FreeBSD XPath fix

### DIFF
--- a/src/xml_xpath_context.cc
+++ b/src/xml_xpath_context.cc
@@ -37,11 +37,9 @@ XmlXpathContext::evaluate(const xmlChar* xpath) {
   v8::Handle<v8::Array> nodes = v8::Array::New(result->nodesetval->nodeNr);
   v8::Handle<v8::Function> push = v8::Handle<v8::Function>::Cast(
     nodes->Get(v8::String::NewSymbol("push")));
-  v8::Handle<v8::Value> argv[1];
   for (int i = 0; i != result->nodesetval->nodeNr; ++i) {
     xmlNode *node = result->nodesetval->nodeTab[i];
-    argv[0] = LibXmlObj::GetMaybeBuild<XmlElement, xmlNode>(node);
-    push->Call(nodes, 1, argv);
+    nodes->Set(i,LibXmlObj::GetMaybeBuild<XmlElement, xmlNode>(node));
   }
 
   xmlXPathFreeObject(result);


### PR DESCRIPTION
I've changed "push" call to Array->Set call. This makes XPath work on 64-bit FreeBSD.
