### PR TITLE
Fix so that libxmljs can build and install via npm on Mac OS X v.10.5.x (Leopard)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -9,7 +9,6 @@ root_dir = dirname(File('SConstruct').rfile().abspath)
 sys.path.insert(0, join(root_dir, 'tools'))
 import js2c
 
-xml2config = 'xml2-config'
 if ARGUMENTS.get('debug', 0):
   node_exe ='node_g'
 else:
@@ -23,6 +22,20 @@ def CheckForNodeJS(context):
   result = shellOut(['which', node_exe]) != ''
   context.Result(result)
   return result
+
+def CheckVersion(a,b):
+    from pkg_resources import parse_version as V
+    return V(a) >= V(b)
+
+def GetLibXml2cflags():
+    minxml2version = '2.7.1'
+    if CheckVersion(shellOut(['xml2-config', '--version']), minxml2version):
+        return shellOut(['xml2-config', '--cflags'])
+    elif os.path.isfile('/opt/local/bin/xml2-config') and CheckVersion(shellOut(['/opt/local/bin/xml2-config', '--version']), minxml2versio$
+        return shellOut(['/opt/local/bin/xml2-config', '--cflags'])
+    else:
+        print 'Your version of libxml2 is too old, exiting.'
+        Exit(1);
 
 using_node_js = (('libxmljs.node' in COMMAND_LINE_TARGETS) or ('test' in COMMAND_LINE_TARGETS))
 
@@ -40,7 +53,7 @@ libpath = [
 #  '-I/usr/include',
 #  '-I/usr/include/libxml2',
 #])
-cflags = shellOut([xml2config, '--cflags'])
+cflags = GetLibXml2cflags()
 
 if using_node_js:
   node_flags = shellOut([node_exe, '--vars'])


### PR DESCRIPTION
libxmljs does not build on Mac OS X v.10.5.x (Leopard) because the version of libxml2 bundled with Leopard is too old. In versions prior to 2.7 (I think), xmlNs does not have a context method, so the code at lines 46-47 of xml_namespace.cc prevent compilation. There was something in xml_node.cc that prevented a compile, as well. Maybe other things.

This revision to SConstruct checks your version of libxml2, and if it's too old, checks to see if you've got another version (located where Macports would install it, by default) that is recent enough. If so, it uses that more recent version of libxml2. (I wasn't going to bother getting too granular, so I picked a release that I'm pretty sure is not too old or unnecessarily recent.)

With this change, I'm able to simply run:
npm install libxmljs

And it just works!
