### PR TITLE
Fix LIBXMLJS_THROW_EXCEPTION, must return exception

### DIFF
--- a/src/libxmljs.h
+++ b/src/libxmljs.h
@@ -41,7 +41,7 @@ do {                                                                          \
 #define LIBXMLJS_THROW_EXCEPTION(err)                                         \
   v8::Local<v8::Value> exception = v8::Exception::TypeError(                  \
     v8::String::New(err));                                                    \
-  ThrowException(exception);
+  return v8::ThrowException(exception);
 
 #define LIBXMLJS_ARGUMENT_TYPE_CHECK(arg, type, err)                          \
   if (!arg->type()) {                                                         \


### PR DESCRIPTION
Seems the return statement in this macro was forgotten.
