### PR TITLE
Silence NPM Warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   }
 , "bugs" :
   { "mail" : ""
-  , "web" : "http://github.com/polotek/libxmljs/issues"
+  , "url" : "http://github.com/polotek/libxmljs/issues"
   }
 , "main" : "./libxmljs"
 , "engines" : { "node" : ">=0.1.90" }


### PR DESCRIPTION
Installing via NPM v1.0.95 results in the following warning being displayed:

`npm WARN libxmljs@0.4.2 package.json: bugs['web'] should probably be bugs['url']`

This change silence this warning.
