### PR TITLE
Make libxmljs compatible with Node 0.6

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -48,6 +48,11 @@ if using_node_js:
 
   if node_flags:
     cflags += ' ' + node_flags.group(1)
+  else:
+    node_prefix = shellOut([node_exe, "-e", "console.log(require('path').dirname(require('path').dirname(process.execPath)))"])
+
+    cflags += ' -I' + node_prefix + '/include'
+    cflags += ' -I' + node_prefix + '/include/node'
 
 testBuilder = Builder(action = 'node spec/tacular.js')
 


### PR DESCRIPTION
`node --vars` in node-0.6 is empty (see [Issue](https://github.com/joyent/node/issues/1536)) and will cause building libxmljs to fail. A similar fix/workaround can be found in this [node-fibers commit](https://github.com/laverdet/node-fibers/commit/c877c39e201026a459d6292033a4741ff5429639).
