### PR TITLE
Adds node v0.4 wscript support

### DIFF
--- a/wscript
+++ b/wscript
@@ -1,4 +1,5 @@
-from os import popen
+from os import popen, symlink, unlink
+from os.path import exists, lexists
 
 srcdir = '.'
 blddir = 'build'
@@ -32,4 +33,9 @@ def build(bld):
     'src/xml_xpath_context.cc',
   ]
   obj.uselib = 'XML2'
+  if exists('build/default') and not exists('build/Release'):
+    symlink('default', 'build/Release')
 
+def clean(bld):
+  if lexists('build/Release'):
+    unlink('build/Release')


### PR DESCRIPTION
Although the module successfully builds under node v0.4, it can't be used in the current form due to hardcoded buid/Release/libxmljs.node path.

It basically symlinks the build/Release from build/default which was in use by node v0.4. Adds a basic clean function for the symlink. Didn't touch any other functionality. For node v0.6 it works as previously did.
