### PR TITLE
Remove global callbacks

### DIFF
--- a/lib/sax_parser.js
+++ b/lib/sax_parser.js
@@ -7,7 +7,7 @@ var SaxParser = function(callbacks) {
     var parser = new bindings.SaxParser();
 
     // attach callbacks
-    for (callback in callbacks) {
+    for (var callback in callbacks) {
         parser.on(callback, callbacks[callback]);
     }
 
@@ -25,7 +25,7 @@ var SaxPushParser = function(callbacks) {
     var parser = new bindings.SaxPushParser();
 
     // attach callbacks
-    for (callback in callbacks) {
+    for (var callback in callbacks) {
         parser.on(callback, callbacks[callback]);
     }
 


### PR DESCRIPTION
Came across these when running Mocha tests against a library that uses `libxml2js`. Mocha detected a "global leak".

This could cause big problems that are impossible to find, particularly because the name of the global is a variable name that is frequently used.

Please note: I ran `npm test` after making the changes and everything checked out. One test is failing, but it also happens to be failing in `master`, and is unrelated to this fix.

Thanks for the great lib!
