### PR TITLE
addChild() causes segfaults (TEXT node merged)

### DIFF
--- a/src/xml_element.cc
+++ b/src/xml_element.cc
@@ -326,7 +326,13 @@ XmlElement::get_attrs() {
 
 void
 XmlElement::add_child(XmlElement* child) {
-  xmlAddChild(xml_obj, child->xml_obj);
+  xmlNodePtr node = xmlAddChild(xml_obj, child->xml_obj);
+  if (node != child->xml_obj)
+  {
+    // xmlAddChild deleted child->xml_obj by merging it with xml_obj last child
+    // recreate a valid xml_obj for child to avoid any memory issue
+    child->xml_obj = xmlNewDocText(xml_obj->doc, (const xmlChar*) "");
+  }
 }
 
 void


### PR DESCRIPTION
When adding a TEXT _xmlNode_ with _addChild()_, it will be merged  by _xmlAddChild()_ with the last child if it's a TEXT node too. In such case, the _XmlElement_ has its _xml_node_ pointing to a freed _xmlNode_.

This is not easily fixed: the argument _child_ may represent no valid _xmlNode_ after the call. What should we do?
- Delete the javascript object? Not possible.
- Make it point to the _xmlNode_ with which it was merged? Either by javascript aliasing, or we will have two _XmlElement_ pointing to the same _xmlNode_, which will create more problems...
- Make a copy of the merged xmlNode before calling _xmlAddChild_ ? This means the chid will not always point to the added child...

This workaround just creates a new unrelated xmlNode to avoid the crashes. 
