### PR TITLE
Fix segfault on broken xpath (+ test case)

### DIFF
--- a/src/xml_xpath_context.cc
+++ b/src/xml_xpath_context.cc
@@ -32,6 +32,11 @@ XmlXpathContext::evaluate(const xmlChar* xpath) {
   if (xpathobj) {
     switch (xpathobj->type) {
     case XPATH_NODESET: {
+      if (xmlXPathNodeSetIsEmpty(xpathobj->nodesetval)) {
+        res = v8::Array::New(0);
+        break;
+      }
+
       v8::Handle<v8::Array> nodes = v8::Array::New(xpathobj->nodesetval->nodeNr);
       for (int i = 0; i != xpathobj->nodesetval->nodeNr; ++i) {
         nodes->Set(i, XmlNode::New(xpathobj->nodesetval->nodeTab[i]));

--- a/test/searching.js
+++ b/test/searching.js
@@ -14,6 +14,15 @@ module.exports.get = function(assert) {
     assert.done();
 };
 
+module.exports.get_missing = function(assert) {
+    var doc = libxml.Document();
+    var root = doc.node('root');
+
+    var missing = doc.get('missing/text()');
+    assert.equal(missing, undefined);
+    assert.done();
+};
+
 module.exports.get_attr = function(assert) {
     var doc = libxml.Document();
     var root = doc.node('root');


### PR DESCRIPTION
Fixes polotek/libxmljs#159
- check for valid XML node set before creating result array
- test case
