### PR TITLE
Encoding and baseUrl can be specified for html

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -56,22 +56,22 @@ Document.prototype.childNodes = function() {
 /// @return a string representation of the document
 Document.prototype.toString = function() {
     return this._toString();
-}
+};
 
 /// @return the document version
 Document.prototype.version = function() {
     return this._version();
-}
+};
 
 /// @return the document encoding
 Document.prototype.encoding = function(encoding) {
     return this._encoding(encoding);
-}
+};
 
 /// @return whether the XmlDocument is valid
 Document.prototype.validate = function(xsd) {
     return this._validate(xsd);
-}
+};
 
 /// @return array of namespaces in document
 Document.prototype.namespaces = function() {
@@ -82,15 +82,23 @@ module.exports = Document;
 
 /// parse a string into a html document
 /// @param string html string to parse
+/// @param {encoding:string, baseUrl:string} opts html string to parse
 /// @return a Document
-module.exports.fromHtml = function(string) {
-    return bindings.fromHtml(string);
-}
+module.exports.fromHtml = function(string, opts) {
+    opts = opts || {};
+
+    // if for some reason user did not specify an object for the options
+    if (typeof(opts) !== 'object') {
+        throw new Error('fromHtml options must be an object');
+    }
+
+    return bindings.fromHtml(string, opts);
+};
 
 /// parse a string into a xml document
 /// @param string xml string to parse
 /// @return a Document
 module.exports.fromXml = function(string) {
     return bindings.fromXml(string);
-}
+};
 

--- a/src/xml_document.cc
+++ b/src/xml_document.cc
@@ -135,6 +135,28 @@ XmlDocument::FromHtml(const v8::Arguments& args)
 {
     v8::HandleScope scope;
 
+    v8::Local<v8::Object> options = args[1]->ToObject();
+    v8::Local<v8::Value>  baseUrlOpt  = options->Get(
+        v8::String::NewSymbol("baseUrl"));
+    v8::Local<v8::Value>  encodingOpt = options->Get(
+        v8::String::NewSymbol("encoding"));
+
+    // the base URL that will be used for this HTML parsed document
+    v8::String::Utf8Value baseUrl_(baseUrlOpt->ToString());
+    const char * baseUrl = *baseUrl_;
+    if (!baseUrlOpt->IsString()) {
+        baseUrl = NULL;
+    }
+
+    // the encoding to be used for this document
+    // (leave NULL for libxml to autodetect)
+    v8::String::Utf8Value encoding_(encodingOpt->ToString());
+    const char * encoding = *encoding_;
+
+    if (!encodingOpt->IsString()) {
+        encoding = NULL;
+    }
+
     v8::Local<v8::Array> errors = v8::Array::New();
     xmlResetLastError();
     xmlSetStructuredErrorFunc(reinterpret_cast<void *>(*errors),
@@ -142,15 +164,15 @@ XmlDocument::FromHtml(const v8::Arguments& args)
 
     htmlDocPtr doc;
     if (!node::Buffer::HasInstance(args[0])) {
-      // Parse a string
-      v8::String::Utf8Value str(args[0]->ToString());
-      doc = htmlReadMemory(*str, str.length(), NULL, NULL, 0);
+        // Parse a string
+        v8::String::Utf8Value str(args[0]->ToString());
+        doc = htmlReadMemory(*str, str.length(), baseUrl, encoding, 0);
     }
     else {
-      // Parse a buffer
-      v8::Local<v8::Object> buf = args[0]->ToObject();
-      doc = htmlReadMemory(node::Buffer::Data(buf), node::Buffer::Length(buf),
-                           NULL, NULL, 0);
+        // Parse a buffer
+        v8::Local<v8::Object> buf = args[0]->ToObject();
+        doc = htmlReadMemory(node::Buffer::Data(buf), node::Buffer::Length(buf),
+                            baseUrl, encoding, 0);
     }
 
     xmlSetStructuredErrorFunc(NULL, NULL);

--- a/test/fixtures/parser.euc_jp.html
+++ b/test/fixtures/parser.euc_jp.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=euc-jp" />
+    <title>テスト</title>
+  </head>
+  <body>
+    <div>テスト</div>
+  </body>
+</html>


### PR DESCRIPTION
Some HTML documents may have incorrect meta tags which puts libxml out
of its default utf-8 parsing mode.  Allow these optional parameters to
parseHtml so users can have control of this in theses situations.
