### PR TITLE
Encode XML special characters when setting element content

### DIFF
--- a/src/xml_element.cc
+++ b/src/xml_element.cc
@@ -38,12 +38,15 @@ XmlElement::New(const v8::Arguments& args) {
       content = strdup(*content_);
   }
 
+  xmlChar* encoded = content ? xmlEncodeSpecialChars(document->xml_obj, (const xmlChar*)content) : NULL;
   xmlNode* elem = xmlNewDocNode(document->xml_obj,
                                 NULL,
                                 (const xmlChar*)*name,
-                                (const xmlChar*)content);
+                                encoded);
   if(content)
       free(content);
+  if(encoded)
+      xmlFree(encoded);
 
   XmlElement* element = new XmlElement(elem);
   elem->_private = element;

--- a/test/element.js
+++ b/test/element.js
@@ -9,6 +9,16 @@ module.exports.new = function(assert) {
     assert.done();
 };
 
+module.exports.newWithContent = function(assert) {
+    var doc = libxml.Document();
+    var elem = libxml.Element(doc, 'name1', 'content && more content <>');
+    doc.root(elem);
+    assert.equal('name1', elem.name());
+    assert.equal('name1', doc.root().name());
+    assert.equal('content && more content <>', elem.text());
+    assert.done();
+};
+
 module.exports.setters = function(assert) {
     var doc = libxml.Document();
     var elem = doc.node('name1');


### PR DESCRIPTION
Previously setting element content like "Barnes & Noble" would result in error.
So I added appropriate encoding using @xmlEncodeSpecialChars@
