### PR TITLE
Expose line numbers when parsing from string

### DIFF
--- a/src/xml_node.cc
+++ b/src/xml_node.cc
@@ -121,6 +121,15 @@ XmlNode::NextSibling(const v8::Arguments& args) {
 }
 
 v8::Handle<v8::Value>
+XmlNode::LineNumber(const v8::Arguments& args) {
+  v8::HandleScope scope;
+  XmlNode *node = ObjectWrap::Unwrap<XmlNode>(args.Holder());
+  assert(node);
+
+  return scope.Close(node->get_line_number());
+}
+
+v8::Handle<v8::Value>
 XmlNode::Type(const v8::Arguments& args) {
   v8::HandleScope scope;
   XmlNode *node = ObjectWrap::Unwrap<XmlNode>(args.Holder());
@@ -293,6 +302,12 @@ XmlNode::get_next_sibling() {
 }
 
 v8::Handle<v8::Value>
+XmlNode::get_line_number() {
+  v8::HandleScope scope;
+  return scope.Close(v8::Integer::New(xmlGetLineNo(xml_obj)));
+}
+
+v8::Handle<v8::Value>
 XmlNode::clone(bool recurse) {
   v8::HandleScope scope;
 
@@ -414,6 +429,10 @@ XmlNode::Initialize(v8::Handle<v8::Object> target) {
   NODE_SET_PROTOTYPE_METHOD(constructor_template,
                         "nextSibling",
                         XmlNode::NextSibling);
+
+  NODE_SET_PROTOTYPE_METHOD(constructor_template,
+                        "line",
+                        XmlNode::LineNumber);
 
   NODE_SET_PROTOTYPE_METHOD(constructor_template,
                         "type",

--- a/src/xml_node.h
+++ b/src/xml_node.h
@@ -28,6 +28,7 @@ protected:
     static v8::Handle<v8::Value> Parent(const v8::Arguments& args);
     static v8::Handle<v8::Value> NextSibling(const v8::Arguments& args);
     static v8::Handle<v8::Value> PrevSibling(const v8::Arguments& args);
+    static v8::Handle<v8::Value> LineNumber(const v8::Arguments& args);
     static v8::Handle<v8::Value> Type(const v8::Arguments& args);
     static v8::Handle<v8::Value> ToString(const v8::Arguments& args);
     static v8::Handle<v8::Value> Remove(const v8::Arguments& args);
@@ -42,6 +43,7 @@ protected:
     v8::Handle<v8::Value> get_parent();
     v8::Handle<v8::Value> get_prev_sibling();
     v8::Handle<v8::Value> get_next_sibling();
+    v8::Handle<v8::Value> get_line_number();
     v8::Handle<v8::Value> clone(bool recurse);
     v8::Handle<v8::Value> get_type();
     v8::Handle<v8::Value> to_string();

--- a/test/xml_parser.js
+++ b/test/xml_parser.js
@@ -14,6 +14,8 @@ module.exports.parse = function(assert) {
     assert.equal('grandchild', doc.get('child').get('grandchild').name());
     assert.equal('with love', doc.get('child/grandchild').text());
     assert.equal('sibling', doc.get('sibling').name());
+    assert.equal(6, doc.get('sibling').line());
+    assert.equal(3, doc.get('child').attr('to').line());
     assert.equal('with content!', doc.get('sibling').text());
     assert.equal(str, doc.toString());
     assert.done();


### PR DESCRIPTION
I hope the utility of line numbers for XML elements is non-controversial.

(It would be nice to also include support for the `xmlParserOption` `XML_PARSE_BIG_LINES`, but this hasn't made its way to my distro's `libxml2` package yet...)
