### PR TITLE
This change allows to create a text item if a name is not specified to the Element constructor

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -13,8 +13,6 @@ var Element = function(doc, name, content) {
     } else if (! (doc instanceof bindings.Document)) {
         throw new Error('document argument must be an ' +
                         'instance of Document');
-    } else if (!name) {
-        throw new Error('name argument required');
     }
 
     var elem = new bindings.Element(doc, name, content);

--- a/src/xml_element.cc
+++ b/src/xml_element.cc
@@ -30,8 +30,6 @@ XmlElement::New(const v8::Arguments& args) {
   XmlDocument* document = ObjectWrap::Unwrap<XmlDocument>(args[0]->ToObject());
   assert(document);
 
-  v8::String::Utf8Value name(args[1]);
-
   v8::Handle<v8::Value> contentOpt;
   if(args[2]->IsString()) {
       contentOpt = args[2];
@@ -40,10 +38,19 @@ XmlElement::New(const v8::Arguments& args) {
   const char* content = (contentRaw.length()) ? *contentRaw : NULL;
 
   xmlChar* encoded = content ? xmlEncodeSpecialChars(document->xml_obj, (const xmlChar*)content) : NULL;
-  xmlNode* elem = xmlNewDocNode(document->xml_obj,
-                                NULL,
-                                (const xmlChar*)*name,
-                                encoded);
+
+  xmlNode* elem;
+
+  if (args[1]->IsString()) {
+    v8::String::Utf8Value name(args[1]);
+    elem = xmlNewDocNode(document->xml_obj,
+                         NULL,
+                         (const xmlChar*)*name,
+                         encoded);
+  } else
+    elem = xmlNewDocText(document->xml_obj,
+                         encoded);
+
   if (encoded)
       xmlFree(encoded);
 


### PR DESCRIPTION
This change allows to create a text instead of a node when the 'name' argument of the Element constructor is not a string. I hope that it makes sense and can be pulled into the base repository. If you believe I should improve it before, please let me know. Thanks. 

See Example:

```
var libxmljs = require('libxmljs')
var doc = new libxmljs.Document();
var root = doc.node('node1');
root.text('Text 1');
var elem1 = libxmljs.Element(doc, 'node2', 'Text 2');
root.addChild(elem1);
// Text:
var elem2 = libxmljs.Element(doc, null, 'Text 3');
root.addChild(elem2);
// Text:
var elem3 = libxmljs.Element(doc, null, '/Text 4');
root.addChild(elem3);
var elem4 = libxmljs.Element(doc, 'node3', 'Text 5');
root.addChild(elem4);
console.log(doc.toString());

produces:

<?xml version="1.0" encoding="UTF-8"?>
<node1>Text 1<node2>Text 2</node2>Text 3/Text 4<node3>Text 5</node3></node1>
```
