### PR TITLE
Update Element.md: changed element.text() to element.value()

### DIFF
--- a/docs/api/Element.md
+++ b/docs/api/Element.md
@@ -34,13 +34,22 @@ The Element class represents an element node in the XML tree.
 >**returns** - the Element object
 
 
-### element.text()
+### element.value()
 
 >Get the text content of the element
 
 >**returns** - a string representing the content of the Element
-  including the text() of all child Nodes
+  including the value() of all child Nodes
 
+
+### element.value(new_name)
+
+>Set the text content of the element
+
+>**args**
+*new_name* - a string representing the new value of the element
+
+>**returns** - the Element object
 
 ### element.attr(name)
 


### PR DESCRIPTION
I tried the .text() method as described in the document and it did not exist. From code inspection, the correct method is .value(). I also added a .value() setter
