### PR TITLE
Fixed ToString formatter.

### DIFF
--- a/src/xml_document.cc
+++ b/src/xml_document.cc
@@ -135,6 +135,8 @@ XmlDocument::ToString(const v8::Arguments& args)
 
     xmlChar* buffer = NULL;
     int len = 0;
+
+    xmlKeepBlanksDefault(0);
     xmlDocDumpFormatMemoryEnc(document->xml_obj, &buffer, &len, "UTF-8", args[0]->BooleanValue() ? 1 : 0);
     v8::Local<v8::String> str = v8::String::New((const char*)buffer, len);
     xmlFree(buffer);


### PR DESCRIPTION
Before there was no difference between the results of doc.toString(true) and doc.toString(false). Now doc.toString(false) returns unformatted XML document string.
