### PR TITLE
Comments: Add initial support and tests

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,7 @@
         'src/xml_attribute.cc',
         'src/xml_document.cc',
         'src/xml_element.cc',
+        'src/xml_comment.cc',
         'src/xml_namespace.cc',
         'src/xml_node.cc',
         'src/xml_sax_parser.cc',

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ module.exports.libxml_debug_enabled = bindings.libxml_debug_enabled;
 // lib exports
 module.exports.Document = Document;
 module.exports.Element = require('./lib/element');
+module.exports.Comment = require('./lib/comment');
 
 // Compatibility synonyms
 Document.fromXmlString = Document.fromXml;

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -1,0 +1,24 @@
+var bindings = require('./bindings');
+
+var Document = require('./document');
+
+/// create a new comment on the given document
+/// @param doc the Document to create the comment for
+/// @param {String} [content] comment content
+/// @constructor
+var Comment = function(doc, content) {
+    if (!doc) {
+        throw new Error('document argument required');
+    } else if (! (doc instanceof bindings.Document)) {
+        throw new Error('document argument must be an ' +
+                        'instance of Document');
+    }
+
+    var comm = new bindings.Comment(doc, content);
+    return comm;
+};
+
+Comment.prototype = bindings.Comment.prototype;
+
+module.exports = Comment;
+

--- a/src/xml_comment.cc
+++ b/src/xml_comment.cc
@@ -1,0 +1,125 @@
+#include <node.h>
+
+#include <cstring>
+
+#include "libxmljs.h"
+
+#include "xml_comment.h"
+#include "xml_document.h"
+#include "xml_attribute.h"
+#include "xml_xpath_context.h"
+
+namespace libxmljs {
+
+v8::Persistent<v8::FunctionTemplate> XmlComment::constructor_template;
+
+// doc, content
+v8::Handle<v8::Value>
+XmlComment::New(const v8::Arguments& args) {
+  v8::HandleScope scope;
+
+  // if we were created for an existing xml node, then we don't need
+  // to create a new node on the document
+  if (args.Length() == 0)
+  {
+      return scope.Close(args.Holder());
+  }
+
+  XmlDocument* document = ObjectWrap::Unwrap<XmlDocument>(args[0]->ToObject());
+  assert(document);
+
+  v8::Handle<v8::Value> contentOpt;
+  if(args[1]->IsString()) {
+      contentOpt = args[1];
+  }
+  v8::String::Utf8Value contentRaw(contentOpt);
+  const char* content = (contentRaw.length()) ? *contentRaw : NULL;
+
+  xmlChar* encoded = content ? xmlEncodeSpecialChars(document->xml_obj, (const xmlChar*)content) : NULL;
+  xmlNode* comm = xmlNewDocComment(document->xml_obj,
+                                   encoded);
+  if (encoded)
+      xmlFree(encoded);
+
+  XmlComment* comment = new XmlComment(comm);
+  comm->_private = comment;
+  comment->Wrap(args.Holder());
+
+  // this prevents the document from going away
+  args.Holder()->Set(v8::String::NewSymbol("document"), args[0]);
+
+  return scope.Close(args.Holder());
+}
+
+v8::Handle<v8::Value>
+XmlComment::Text(const v8::Arguments& args) {
+  v8::HandleScope scope;
+  XmlComment *comment = ObjectWrap::Unwrap<XmlComment>(args.Holder());
+  assert(comment);
+
+  if (args.Length() == 0) {
+    return scope.Close(comment->get_content());
+  } else {
+    comment->set_content(*v8::String::Utf8Value(args[0]));
+  }
+
+  return scope.Close(args.Holder());
+}
+
+void
+XmlComment::set_content(const char* content) {
+  xmlChar *encoded = xmlEncodeSpecialChars(xml_obj->doc, (const xmlChar*)content);
+  xmlNodeSetContent(xml_obj, encoded);
+  xmlFree(encoded);
+}
+
+v8::Handle<v8::Value>
+XmlComment::get_content() {
+  xmlChar* content = xmlNodeGetContent(xml_obj);
+  if (content) {
+    v8::Handle<v8::String> ret_content =
+      v8::String::New((const char *)content);
+    xmlFree(content);
+    return ret_content;
+  }
+
+  return v8::String::Empty();
+}
+
+
+v8::Handle<v8::Object>
+XmlComment::New(xmlNode* node)
+{
+    if (node->_private) {
+        return static_cast<XmlNode*>(node->_private)->handle_;
+    }
+
+    XmlComment* comment = new XmlComment(node);
+    v8::Local<v8::Object> obj = constructor_template->GetFunction()->NewInstance();
+    comment->Wrap(obj);
+    return obj;
+}
+
+XmlComment::XmlComment(xmlNode* node)
+    : XmlNode(node)
+{
+}
+
+void
+XmlComment::Initialize(v8::Handle<v8::Object> target)
+{
+    v8::HandleScope scope;
+    v8::Local<v8::FunctionTemplate> t = v8::FunctionTemplate::New(New);
+    constructor_template = v8::Persistent<v8::FunctionTemplate>::New(t);
+    constructor_template->Inherit(XmlNode::constructor_template);
+    constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
+
+    NODE_SET_PROTOTYPE_METHOD(constructor_template,
+            "text",
+            XmlComment::Text);
+
+    target->Set(v8::String::NewSymbol("Comment"),
+            constructor_template->GetFunction());
+}
+
+}  // namespace libxmljs

--- a/src/xml_comment.h
+++ b/src/xml_comment.h
@@ -1,0 +1,32 @@
+#ifndef SRC_XML_COMMENT_H_
+#define SRC_XML_COMMENT_H_
+
+#include "libxmljs.h"
+#include "xml_node.h"
+
+namespace libxmljs {
+
+class XmlComment : public XmlNode {
+public:
+
+    explicit XmlComment(xmlNode* node);
+
+    static void Initialize(v8::Handle<v8::Object> target);
+
+    static v8::Persistent<v8::FunctionTemplate> constructor_template;
+
+    // create new xml comment to wrap the node
+    static v8::Handle<v8::Object> New(xmlNode* node);
+
+protected:
+
+    static v8::Handle<v8::Value> New(const v8::Arguments& args);
+    static v8::Handle<v8::Value> Text(const v8::Arguments& args);
+    
+    void set_content(const char* content);
+    v8::Handle<v8::Value> get_content();
+};
+
+}  // namespace libxmljs
+
+#endif  // SRC_XML_COMMENT_H_

--- a/src/xml_node.cc
+++ b/src/xml_node.cc
@@ -8,6 +8,7 @@
 #include "xml_document.h"
 #include "xml_namespace.h"
 #include "xml_element.h"
+#include "xml_comment.h"
 #include "xml_attribute.h"
 
 namespace libxmljs {
@@ -451,6 +452,7 @@ XmlNode::Initialize(v8::Handle<v8::Object> target) {
                         XmlNode::ToString);
 
   XmlElement::Initialize(target);
+  XmlComment::Initialize(target);
   XmlAttribute::Initialize(target);
 }
 }  // namespace libxmljs

--- a/test/comment.js
+++ b/test/comment.js
@@ -1,0 +1,18 @@
+var libxml = require('../index');
+
+module.exports.new = function(assert) {
+    var doc = libxml.Document();
+    var comm = libxml.Comment(doc, 'comment1');
+    doc.root(comm);
+    assert.equal('comment1', comm.text());
+    assert.done();
+};
+
+module.exports.text = function(assert) {
+    var doc = libxml.Document();
+    var comm = libxml.Comment(doc);
+    comm.text('comment2');
+    assert.equal('comment2', comm.text());
+    assert.done();
+};
+


### PR DESCRIPTION
- This commit makes it possible to create
  XML commment nodes in nodejs.
- A new XmlComment class is introduced
  which exports a method text() to get and set
  the comment content.
- This patch also includes tests to assert comment
  creation and the getting and setting of comment
  content through the text() function.
