### PR TITLE
HTML document throws better errors when there is no root node

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2,6 +2,12 @@ var bindings = require('./bindings');
 
 var Element = require('./element');
 
+function assertRoot(doc) {
+    if(!doc.root()) {
+        throw new Error('Document has no root element');
+    }
+}
+
 /// Create a new document
 /// @param {string} version xml version, default 1.0
 /// @param {string} encoding the encoding, default utf8
@@ -31,12 +37,16 @@ Document.prototype.node = function(name, content) {
 /// xpath search
 /// @return array of matching elements
 Document.prototype.find = function(xpath, ns_uri) {
+    assertRoot(this);
+
     return this.root().find(xpath, ns_uri);
 };
 
 /// xpath search
 /// @return first element matching
 Document.prototype.get = function(xpath, ns_uri) {
+    assertRoot(this);
+
     return this.root().get(xpath, ns_uri);
 };
 
@@ -45,11 +55,16 @@ Document.prototype.child = function(id) {
     if (id === undefined || typeof id !== 'number') {
         throw new Error('id argument required for #child');
     }
+
+    assertRoot(this);
+
     return this.root().child(id);
 };
 
 /// @return an Array of child nodes of the document root
 Document.prototype.childNodes = function() {
+    assertRoot(this);
+
     return this.root().childNodes();
 };
 
@@ -97,6 +112,8 @@ Document.prototype.setDtd = function(name, ext, sys) {
 
 /// @return array of namespaces in document
 Document.prototype.namespaces = function() {
+    assertRoot(this);
+
     return this.root().namespaces();
 };
 

--- a/test/document.js
+++ b/test/document.js
@@ -228,4 +228,38 @@ module.exports.validate = function(assert) {
     assert.equal(xmlDocInvalid.validationErrors.length, 1);
 
     assert.done();
-}
+};
+
+module.exports.errors = {
+    empty_html_doc: function(assert) {
+        function assertDocRootError(func, msg) {
+            assert.throws(func, /Document has no root element/, msg);
+        }
+
+        var xml_only_comments = '<!-- empty -->';
+        var doc = libxml.parseHtmlString(xml_only_comments);
+        assert.equal(null, doc.root());
+
+        assertDocRootError(function() {
+            doc.get('*');
+        }, 'get method throws correct error on empty doc');
+
+        assertDocRootError(function() {
+            doc.find('*');
+        }, 'find method throws correct error on empty doc');
+
+        assertDocRootError(function() {
+            doc.child(1);
+        }, 'child method throws correct error on empty doc');
+
+        assertDocRootError(function() {
+            doc.childNodes();
+        }, 'childNodes method throws correct error on empty doc');
+
+        assertDocRootError(function() {
+            doc.namespaces();
+        }, 'namespaces method throws correct error on empty doc');
+
+        assert.done();
+    }
+};


### PR DESCRIPTION
HTML documents have lax parsing and can be created even without a root node. This results in errors when the document defers methods to the root node. This patch catches that circumstance and throws more descriptive errors to let you know what went wrong.

closes #245 
