### PR TITLE
add assertion to catch failed attribute creation

### DIFF
--- a/src/xml_attribute.cc
+++ b/src/xml_attribute.cc
@@ -15,6 +15,7 @@ v8::Local<v8::Object>
 XmlAttribute::New(xmlNode* xml_obj, const xmlChar* name, const xmlChar* value)
 {
     xmlAttr* attr = xmlSetProp(xml_obj, name, value);
+    assert(attr);
 
     if (attr->_private) {
         return NanObjectWrapHandle(static_cast<XmlNode*>(xml_obj->_private));


### PR DESCRIPTION
This problem was surfaced by issue #268. We weren't doing a proper check for failed attribute creation in the attr method. This still fails and segaults, but the reason is now obvious.
