### PR TITLE
Make memory usage tracking thread-safe

### DIFF
--- a/src/libxmljs.cc
+++ b/src/libxmljs.cc
@@ -2,6 +2,7 @@
 
 #include <v8.h>
 #include <uv.h>
+#include "uv-compat.h"
 
 #include <libxml/xmlmemory.h>
 

--- a/src/uv-compat.h
+++ b/src/uv-compat.h
@@ -2,7 +2,9 @@
 
 #if NAUV_UVVERSION < 0x10000
 
-#ifndef _WIN32
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <pthread.h>
 #endif
 
@@ -13,5 +15,15 @@ NAN_INLINE int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2) {
     return pthread_equal(*t1, *t2);
 #endif
 }
+
+#if !NODE_VERSION_AT_LEAST(0, 9, 2)
+NAN_INLINE uv_thread_t uv_thread_self() {
+#ifdef _WIN32
+    return GetCurrentThreadId();
+#else
+    return pthread_self();
+#endif
+}
+#endif
 
 #endif

--- a/src/uv-compat.h
+++ b/src/uv-compat.h
@@ -1,0 +1,17 @@
+#include <nan.h>
+
+#if NAUV_UVVERSION < 0x10000
+
+#ifndef _WIN32
+#include <pthread.h>
+#endif
+
+NAN_INLINE int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2) {
+#ifdef _WIN32
+    return *t1 == *t2;
+#else
+    return pthread_equal(*t1, *t2);
+#endif
+}
+
+#endif

--- a/vendor/libxml/include/libxml/xmlversion.h
+++ b/vendor/libxml/include/libxml/xmlversion.h
@@ -90,11 +90,20 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * Whether the thread support is configured in
  */
-#if 0
+#if 1
 #if defined(_REENTRANT) || defined(__MT__) || \
     (defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE - 0 >= 199506L))
 #define LIBXML_THREAD_ENABLED
 #endif
+#endif
+
+/**
+ * LIBXML_THREAD_ALLOC_ENABLED:
+ *
+ * Whether the allocation hooks are per-thread
+ */
+#if 0
+#define LIBXML_THREAD_ALLOC_ENABLED
 #endif
 
 /**


### PR DESCRIPTION
Fixes #296. This keeps track of allocation sizes by adding a header to
every allocation holding the size. The difference between the memory
usage we've last reported to V8 and the current memory usage is tracked
in `xml_memory_diff`, and protected by `xml_memory_mutex`. It is
frequently synchronised by `xml_memory_cb`, which is called on the main
thread through `xml_memory_handle`.
