### PR TITLE
New Document method to read XML from file

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,9 @@ var Document = require('./lib/document');
 /// parse an xml string and return a Document
 module.exports.parseXml = Document.fromXml;
 
+/// parse an xml file and return a Document
+module.exports.parseXmlFile = Document.fromXmlFile;
+
 /// parse an html string and return a Document
 module.exports.parseHtml = Document.fromHtml;
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -146,3 +146,10 @@ module.exports.fromXml = function(string, options) {
     return bindings.fromXml(string, options || {});
 };
 
+/// parse given file contents into a xml document
+/// @param string file path to file
+/// @return a Document
+module.exports.fromXmlFile = function(file, options) {
+    return bindings.fromXmlFile(file, options || {});
+};
+

--- a/src/xml_document.h
+++ b/src/xml_document.h
@@ -42,6 +42,7 @@ protected:
     static NAN_METHOD(New);
     static NAN_METHOD(FromHtml);
     static NAN_METHOD(FromXml);
+    static NAN_METHOD(FromXmlFile);
     static NAN_METHOD(SetDtd);
 
     // document handle methods

--- a/test/xml_parser.js
+++ b/test/xml_parser.js
@@ -37,6 +37,24 @@ module.exports.parse_synonym = function(assert) {
     assert.done();
 }
 
+module.exports.parse_file = function(assert) {
+    var filename = __dirname + '/fixtures/parser.xml';
+
+    var doc = libxml.parseXmlFile(filename);
+    assert.equal('1.0', doc.version());
+    assert.equal('UTF-8', doc.encoding());
+    assert.equal('root', doc.root().name());
+    assert.equal('child', doc.get('child').name());
+    assert.equal('grandchild', doc.get('child').get('grandchild').name());
+    assert.equal('with love', doc.get('child/grandchild').text());
+    assert.equal('sibling', doc.get('sibling').name());
+    assert.equal(6, doc.get('sibling').line());
+    assert.equal(3, doc.get('child').attr('to').line());
+    assert.equal('with content!', doc.get('sibling').text());
+    assert.equal(fs.readFileSync(filename, 'utf8'), doc.toString());
+    assert.done();
+};
+
 module.exports.recoverable_parse = function(assert) {
     var filename = __dirname + '/fixtures/warnings/ent9.xml';
     var str = fs.readFileSync(filename, 'utf8');


### PR DESCRIPTION
Added `XmlDocument::FromXmlFile` method to read XML from file.

The reason behind this method is to use parsed XML document which contains references to other files. For example, to parse XML document as XSLT stylesheet with https://github.com/albanm/node-libxslt

Without proper file-based xml parsing context it is not possible to parse XSLT stylesheets that contain, for example, `<xsl:import href="..."/>` references.
