### PR TITLE
Use AppVeyor configuration from libxmljs-mt

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+environment:
+ matrix:
+  - nodejs_version: LTS
+  - nodejs_version: Stable
+
+os:
+  - Visual Studio 2013
+  - Visual Studio 2015
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - node --version
+  - npm --version
+  - git submodule update --init --recursive
+
+build_script:
+  - npm install
+
+test_script:
+  - npm test
+
+deploy: off


### PR DESCRIPTION
You may want to use this instead of #382, since the file here is tested in practice in my fork. Originally a previous version of this file was part of #361 which you wanted split up.
