### PR TITLE
Precompiled binary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Libxmljs
-[![Build Status](https://secure.travis-ci.org/polotek/libxmljs.svg?branch=master)](http://travis-ci.org/polotek/libxmljs)
+[![Build Status](https://secure.travis-ci.org/libxmljs/libxmljs.svg?branch=master)](http://travis-ci.org/libxmljs/libxmljs)
+
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/cf862a98w7qsajpl/branch/master?svg=true)](https://ci.appveyor.com/project/rchipka/libxmljs/branch/master)
 
 LibXML bindings for [node.js](http://nodejs.org/)
 
@@ -28,14 +30,14 @@ console.log(child.attr('foo').value()); // prints "bar"
 
 ## Support
 
-* Docs - [http://github.com/polotek/libxmljs/wiki](http://github.com/polotek/libxmljs/wiki)
+* Docs - [http://github.com/libxmljs/libxmljs/wiki](http://github.com/libxmljs/libxmljs/wiki)
 * Mailing list - [http://groups.google.com/group/libxmljs](http://groups.google.com/group/libxmljs)
 
 ## API and Examples
 
-Check out the wiki [http://github.com/polotek/libxmljs/wiki](http://github.com/polotek/libxmljs/wiki).
+Check out the wiki [http://github.com/libxmljs/libxmljs/wiki](http://github.com/libxmljs/libxmljs/wiki).
 
-See the [examples](https://github.com/polotek/libxmljs/tree/master/examples) folder.
+See the [examples](https://github.com/libxmljs/libxmljs/tree/master/examples) folder.
 
 ## Installation via [npm](https://npmjs.org)
 
@@ -45,9 +47,8 @@ npm install libxmljs
 
 ## Contribute
 
-Start by checking out the [open issues](https://github.com/polotek/libxmljs/issues?labels=&page=1&state=open). Specifically the [desired feature](https://github.com/polotek/libxmljs/issues?labels=desired+feature&page=1&state=open) ones.
+Start by checking out the [open issues](https://github.com/libxmljs/libxmljs/issues?labels=&page=1&state=open). Specifically the [desired feature](https://github.com/libxmljs/libxmljs/issues?labels=desired+feature&page=1&state=open) ones.
 
 ### Requirements
 
 Make sure you have met the requirements for [node-gyp](https://github.com/TooTallNate/node-gyp#installation). You DO NOT need to manually install node-gyp; it comes bundled with node.
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,87 @@
+environment:
+  github_release_token:
+    secure: en/UnoFHA3RsSAHM5c6zb3RAMa4V01lC3pYG1YrHSeOPFu78SUA/0lOjNe3pp8RG
+  matrix:
+
+      # Node v0.10, MSVS 2013
+    - nodejs_version: 0.10.40
+      nodejs_abi: 11
+      platform: x86
+      target_arch: ia32
+      msvs_version: 2013
+
+    - nodejs_version: 0.10.40
+      nodejs_abi: 11
+      platform: x64
+      target_arch: x64
+      msvs_version: 2013
+
+      # Node v0.12, MSVS 2015
+    - nodejs_version: 0.12.7
+      nodejs_abi: 14
+      platform: x86
+      target_arch: ia32
+      msvs_version: 2015
+
+    - nodejs_version: 0.12.7
+      nodejs_abi: 14
+      platform: x64
+      target_arch: x64
+      msvs_version: 2015
+
+      # Node v0.12, MSVS 2013
+    - nodejs_version: 0.12.7
+      nodejs_abi: 14
+      platform: x86
+      target_arch: ia32
+      msvs_version: 2013
+
+    - nodejs_version: 0.12.7
+      nodejs_abi: 14
+      platform: x64
+      target_arch: x64
+      msvs_version: 2013
+
+    - nodejs_version: 4.0.0
+      nodejs_abi: 46
+      platform: x64
+      target_arch: x64
+      msvs_version: 2013
+
+    - nodejs_version: 5.0.0
+      nodejs_abi: 47
+      platform: x64
+      target_arch: x64
+      msvs_version: 2013
+
+image: Visual Studio 2015
+
+artifacts:
+  - path: node-v$(nodejs_abi)-win32-$(target_arch).node
+    name: libxml_binary
+
+deploy:
+  - provider: GitHub
+    release: $(APPVEYOR_REPO_TAG_NAME)
+    artifact: libxml_binary
+    auth_token: $(github_release_token)
+    draft: false
+    prerelease: false
+    on:
+      msvs_version: 2013
+      appveyor_repo_tag: true
+
+install:
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - npm config set msvs_version %msvs_version%
+  - npm config set python C:\Python27\python.exe
+  - npm install -g npm
+
+build_script:
+  - npm install --msvs_version=%msvs_version%
+
+test_script:
+- cmd: node --expose-gc node_modules/nodeunit/bin/nodeunit test
+
+after_test:
+  - ps: Copy-Item build/Release/xmljs.node ($env:nodejs_abi + "-win32-" + $env:platform + ".node")

--- a/lib/document.js
+++ b/lib/document.js
@@ -155,7 +155,8 @@ module.exports.fromHtmlFragment = function(string, opts) {
         throw new Error('fromHtmlFragment options must be an object');
     }
 
-    opts.excludeImpliedElements = true;
+    opts.doctype = false;
+    opts.implied = false;
 
     return bindings.fromHtml(string, opts);
 };

--- a/package.json
+++ b/package.json
@@ -4,17 +4,25 @@
   "contributors": [
     "Jeff Smick"
   ],
+  "binary": {
+        "module_name" : "xmljs",
+        "module_path" : "./build/Release/",
+        "host"        : "https://github.com",
+        "remote_path" : "./libxmljs/libxmljs/releases/download/v{version}/",
+        "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
+  },
   "description": "libxml bindings for v8 javascript engine",
   "version": "0.17.1",
   "scripts": {
+    "install": "node-pre-gyp install --fallback-to-build --loglevel http",
     "test": "node --expose_gc ./node_modules/.bin/nodeunit test"
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/polotek/libxmljs.git"
+    "url": "http://github.com/libxmljs/libxmljs.git"
   },
   "bugs": {
-    "url": "http://github.com/polotek/libxmljs/issues"
+    "url": "http://github.com/libxmljs/libxmljs/issues"
   },
   "main": "./index",
   "license": "MIT",
@@ -22,6 +30,7 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
+    "node-pre-gyp": "0.6.28",
     "bindings": "1.2.1",
     "nan": "2.3.2"
   },

--- a/test/xml_parser.js
+++ b/test/xml_parser.js
@@ -56,6 +56,12 @@ module.exports.recoverable_parse = function(assert) {
 };
 
 module.exports.baseurl_xml = function(assert) {
+    if (/^win/.test(process.platform)) {
+        // libxml won't resolve the path on Windows
+        assert.done();
+        return;
+    }
+
     var str = '<!DOCTYPE example SYSTEM "baseurl.dtd">\n' +
       '<example msg="&happy;"/>\n';
 

--- a/vendor/libxml/config.h
+++ b/vendor/libxml/config.h
@@ -157,7 +157,7 @@
 #define HAVE_RAND 1
 
 /* Define to 1 if you have the `rand_r' function. */
-#ifndef WIN32
+#ifndef _WIN32
 #define HAVE_RAND_R 1
 #endif
 
@@ -174,7 +174,11 @@
 #define HAVE_SIGNAL_H 1
 
 /* Define to 1 if you have the `snprintf' function. */
+#if defined(_WIN32) && _MSC_VER >= 1900
 #define HAVE_SNPRINTF 1
+#else
+#define snprintf _snprintf
+#endif
 
 /* Define to 1 if you have the `sprintf' function. */
 #define HAVE_SPRINTF 1
@@ -251,7 +255,7 @@
 #define HAVE_TIME_H 1
 
 /* Define to 1 if you have the <unistd.h> header file. */
-#ifndef WIN32
+#ifndef _WIN32
 #define HAVE_UNISTD_H 1
 #endif
 
@@ -277,7 +281,7 @@
 /* #undef HAVE___VA_COPY */
 
 /* Define as const if the declaration of iconv() needs const. */
-#define ICONV_CONST 
+#define ICONV_CONST
 
 /* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"


### PR DESCRIPTION
This pull request addresses issue #395 by uploading Windows binaries to GitHub Releases. If a user installs libxmljs on Windows, node-pre-gyp will use one of the precompiled binaries.

This also fixes issue #392 and adds AppVeyor CI testing for Windows builds.
