### PR TITLE
Include upstream copyright notice

### DIFF
--- a/vendor/libxml/Copyright
+++ b/vendor/libxml/Copyright
@@ -1,0 +1,23 @@
+Except where otherwise noted in the source code (e.g. the files hash.c,
+list.c and the trio files, which are covered by a similar licence but
+with different Copyright notices) all the files are:
+
+ Copyright (C) 1998-2012 Daniel Veillard.  All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is fur-
+nished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FIT-
+NESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
The the [libxml2 vendor subdirectory](https://github.com/libxmljs/libxmljs/tree/e1cea0583a383f34f65919758c5c2e92844c8b5f/vendor/libxml) of libxmljs does not contain the [upstream copyright notice](https://git.gnome.org/browse/libxml2/tree/Copyright?id=7e86eb5d4b1d3fa0e97a90661e098e641b4cde99) even though the MIT license wording states that

> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software

as *the* sole condition of use. We should make sure to include them in the source repository, and in the sources as provided by the npm registry.