### PR TITLE
Fix travis-ci links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Libxmljs
-[![Build Status](https://secure.travis-ci.org/polotek/libxmljs.svg?branch=master)](http://travis-ci.org/polotek/libxmljs)
+[![Build Status](https://secure.travis-ci.org/libxmljs/libxmljs.svg?branch=master)](http://travis-ci.org/libxmljs/libxmljs)
 
 LibXML bindings for [node.js](http://nodejs.org/)
 


### PR DESCRIPTION
It seems like the repository was moved from the @polotek user to the @libxmljs organization.

This patch changes the link and image to point to the new location.
