### PR TITLE
Windows builds for Node 6 & 7

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,10 +54,22 @@ environment:
       target_arch: x64
       msvs_version: 2013
 
+    - nodejs_version: 6.0.0
+      nodejs_abi: 48
+      platform: x64
+      target_arch: x64
+      msvs_version: 2013
+
+    - nodejs_version: 7.0.0
+      nodejs_abi: 51
+      platform: x64
+      target_arch: x64
+      msvs_version: 2013
+
 image: Visual Studio 2015
 
 artifacts:
-  - path: node-v$(nodejs_abi)-win32-$(target_arch).node
+  - path: $(artifact_path)
     name: libxml_binary
 
 deploy:
@@ -84,4 +96,6 @@ test_script:
 - cmd: node --expose-gc node_modules/nodeunit/bin/nodeunit test
 
 after_test:
-  - ps: Copy-Item build/Release/xmljs.node ($env:nodejs_abi + "-win32-" + $env:platform + ".node")
+  - ps: $env:artifact_path = "node-v" + $env:nodejs_abi + "-win32-" + $env:target_arch + ".node"
+  - ps: Copy-Item build/Release/xmljs.node ($env:artifact_path)
+  - ps: echo ("Created artifact " + $env:artifact_path)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "module_path" : "./build/Release/",
         "host"        : "https://github.com",
         "remote_path" : "./libxmljs/libxmljs/releases/download/v{version}/",
-        "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
+        "package_name": "node-v{node_abi}-{platform}-{arch}.node"
   },
   "description": "libxml bindings for v8 javascript engine",
   "version": "0.18.0",

--- a/test/document.js
+++ b/test/document.js
@@ -253,7 +253,7 @@ module.exports.rngValidate = function(assert) {
 			'</zeroOrMore>'+
 		'</element>';
 
-	var xml_valid = 
+	var xml_valid =
 		'<addressBook>'+
 			'<card>'+
 				'<name>John Smith</name>'+
@@ -265,7 +265,7 @@ module.exports.rngValidate = function(assert) {
 			'</card>'+
 		'</addressBook>';
 
-	var xml_invalid = 
+	var xml_invalid =
 		'<addressBook>'+
 			'<card>'+
 				'<Name>John Smith</Name>'+
@@ -280,7 +280,7 @@ module.exports.rngValidate = function(assert) {
     var rngDoc = libxml.parseXml(rng);
     var xmlDocValid = libxml.parseXml(xml_valid);
     var xmlDocInvalid = libxml.parseXml(xml_invalid);
-	
+
     assert.equal(xmlDocValid.rngValidate(rngDoc), true);
     assert.equal(xmlDocValid.validationErrors.length, 0);
 
@@ -395,17 +395,17 @@ module.exports.validate_rng_memory_usage = function(assert) {
     assert.done();
 };
 
-var VALIDATE_RSS_TOLERANCE = 100000;
+var VALIDATE_RSS_TOLERANCE = 1;
 
 function rssAfterGarbageCollection(maxCycles) {
     maxCycles || (maxCycles = 10);
 
-    var rss = process.memoryUsage().rss;
+    var rss = libxml.memoryUsage();
     var freedMemory = 0;
     do {
         global.gc();
 
-        var rssAfterGc = process.memoryUsage().rss;
+        var rssAfterGc = libxml.memoryUsage();
         freedMemory = rss - rssAfterGc;
         rss = rssAfterGc;
 
@@ -415,4 +415,3 @@ function rssAfterGarbageCollection(maxCycles) {
 
     return rss;
 }
-


### PR DESCRIPTION
Adds AppVeyor build support for Node version 6 and 7.

@defunctzombie @polotek All you have to do is bump the version with a tagged commit, publish to NPM, and libxmljs users can start using Windows binaries. 🎈🎉