### PR TITLE
New build archs, deploy as tar.gz, always use MSVS 2015

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,75 +2,38 @@ environment:
   github_release_token:
     secure: en/UnoFHA3RsSAHM5c6zb3RAMa4V01lC3pYG1YrHSeOPFu78SUA/0lOjNe3pp8RG
   matrix:
+    - nodejs_version: 0.10
+    - nodejs_version: 0.12
+    - nodejs_version: 4
+    - nodejs_version: 5
+    - nodejs_version: 6
+    - nodejs_version: 7
 
-      # Node v0.10, MSVS 2013
-    - nodejs_version: 0.10.40
-      nodejs_abi: 11
-      platform: x86
-      target_arch: ia32
-      msvs_version: 2013
-
-    - nodejs_version: 0.10.40
-      nodejs_abi: 11
-      platform: x64
-      target_arch: x64
-      msvs_version: 2013
-
-      # Node v0.12, MSVS 2015
-    - nodejs_version: 0.12.7
-      nodejs_abi: 14
-      platform: x86
-      target_arch: ia32
-      msvs_version: 2015
-
-    - nodejs_version: 0.12.7
-      nodejs_abi: 14
-      platform: x64
-      target_arch: x64
-      msvs_version: 2015
-
-      # Node v0.12, MSVS 2013
-    - nodejs_version: 0.12.7
-      nodejs_abi: 14
-      platform: x86
-      target_arch: ia32
-      msvs_version: 2013
-
-    - nodejs_version: 0.12.7
-      nodejs_abi: 14
-      platform: x64
-      target_arch: x64
-      msvs_version: 2013
-
-    - nodejs_version: 4.0.0
-      nodejs_abi: 46
-      platform: x64
-      target_arch: x64
-      msvs_version: 2013
-
-    - nodejs_version: 5.0.0
-      nodejs_abi: 47
-      platform: x64
-      target_arch: x64
-      msvs_version: 2013
-
-    - nodejs_version: 6.0.0
-      nodejs_abi: 48
-      platform: x64
-      target_arch: x64
-      msvs_version: 2013
-
-    - nodejs_version: 7.0.0
-      nodejs_abi: 51
-      platform: x64
-      target_arch: x64
-      msvs_version: 2013
+platform:
+  - x86
+  - x64
 
 image: Visual Studio 2015
 
 artifacts:
-  - path: $(artifact_path)
+  - path: build\**\*.tar.gz
     name: libxml_binary
+
+install:
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - npm config set msvs_version 2015
+  - npm config set python C:\Python27\python.exe
+  - npm install -g npm
+  - npm install -g node-pre-gyp
+
+build_script:
+  - npm install --msvs_version=2015
+
+test_script:
+- cmd: node --expose-gc node_modules/nodeunit/bin/nodeunit test
+
+after_test:
+  - cmd: node-pre-gyp package 2>&1
 
 deploy:
   - provider: GitHub
@@ -80,22 +43,9 @@ deploy:
     draft: false
     prerelease: false
     on:
-      msvs_version: 2013
       appveyor_repo_tag: true
 
-install:
-  - ps: Install-Product node $env:nodejs_version $env:platform
-  - npm config set msvs_version %msvs_version%
-  - npm config set python C:\Python27\python.exe
-  - npm install -g npm
-
-build_script:
-  - npm install --msvs_version=%msvs_version%
-
-test_script:
-- cmd: node --expose-gc node_modules/nodeunit/bin/nodeunit test
-
-after_test:
-  - ps: $env:artifact_path = "node-v" + $env:nodejs_abi + "-win32-" + $env:target_arch + ".node"
-  - ps: Copy-Item build/Release/xmljs.node ($env:artifact_path)
-  - ps: echo ("Created artifact " + $env:artifact_path)
+after_deploy:
+  - node-pre-gyp clean
+  - npm install --fallback-to-build=false
+  - cmd: node --expose-gc node_modules/nodeunit/bin/nodeunit test

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "module_path" : "./build/Release/",
         "host"        : "https://github.com",
         "remote_path" : "./libxmljs/libxmljs/releases/download/v{version}/",
-        "package_name": "{node_abi}-{platform}-{arch}.node"
+        "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
   },
   "description": "libxml bindings for v8 javascript engine",
   "version": "0.18.1",


### PR DESCRIPTION
More binary support for Windows.