### PR TITLE
Bump NAN to v2.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "node-pre-gyp": "0.6.28",
     "bindings": "1.2.1",
-    "nan": "2.3.2"
+    "nan": "~2.5.0"
   },
   "devDependencies": {
     "nodeunit": "0.9.0"


### PR DESCRIPTION
Upgrade NAN to version 2.5 and allow the use of newer patch versions.

This is not a regression back to [the last time we allowed newer NAN versions](https://github.com/libxmljs/libxmljs/commit/70dd1d6c1504a1831f8a2deb78f40da6dc82c128).

We were allowing minor version bumps of NAN, which caused problems. Allowing patch versions can't hurt since NAN [follows semver](https://github.com/nodejs/nan/issues/215). 