### PR TITLE
Load native node module from lib/binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build/
 node_modules/
 npm-debug.log
+lib/binding/

--- a/binding.gyp
+++ b/binding.gyp
@@ -74,6 +74,17 @@
           },
         }]
       ]
+    },
+    {
+      "target_name": "action_after_build",
+      "type": "none",
+      "dependencies": [ "<(module_name)" ],
+      "copies": [
+          {
+            "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
+            "destination": "<(module_path)"
+          }
+      ]
     }
   ]
 }

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -1,1 +1,5 @@
-module.exports = require('bindings')('xmljs');
+var binary = require('node-pre-gyp');
+var path = require('path');
+var binding_path = binary.find(path.resolve(path.join(__dirname, '../package.json')));
+var binding = require(binding_path);
+module.exports = binding;

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   ],
   "binary": {
         "module_name" : "xmljs",
-        "module_path" : "./build/Release/",
+        "module_path" : "./lib/binding/{node_abi}-{platform}-{arch}",
         "host"        : "https://github.com",
         "remote_path" : "./libxmljs/libxmljs/releases/download/v{version}/",
         "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
   },
   "description": "libxml bindings for v8 javascript engine",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build --loglevel http",
     "test": "node --expose_gc ./node_modules/.bin/nodeunit test"
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "node-pre-gyp": "~0.6.32",
-    "bindings": "1.2.1",
     "nan": "~2.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is a fix for Issue [458](https://github.com/libxmljs/libxmljs/issues/458)

These changes move the native node module into `./lib/binding/{node_abi}-{platform}-{arch}/` instead of `./build/Release/`

This is similar to what sqlite3 does, and this is the recommended way according to the node-pre-gyp docs

In binding.gyp, there's an `action_after_build` task that copies the native node module to the correct path specified in package.json

Changes in `lib/bindings.js` now use node-pre-gyp to resolve the path to `xmljs.node` from package.json