### PR TITLE
fix to array detection

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -62,7 +62,7 @@ Element.prototype.cdata = function(content) {
 
 Element.prototype.get = function() {
     var res = this.find.apply(this, arguments);
-    if (res instanceof Array) {
+    if (Array.isArray(res)) {
         return res[0];
     } else {
         return res;
@@ -79,4 +79,3 @@ Element.prototype.defineNamespace = function(prefix, href) {
 };
 
 module.exports = Element;
-


### PR DESCRIPTION
An array is an instance of an object, so the check `res instanceof Array` will return false, even in case of an array. Hence, I replaced it with `Array.isArray(res)`. This solved quite a few issues for me :smile: 