### PR TITLE
Document find in the front README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,31 @@
 LibXML bindings for [node.js](http://nodejs.org/)
 
 ```javascript
-var libxmljs = require("libxmljs");
+var libxml = require("libxmljs");
 var xml =  '<?xml version="1.0" encoding="UTF-8"?>' +
            '<root>' +
                '<child foo="bar">' +
                    '<grandchild baz="fizbuzz">grandchild content</grandchild>' +
+                   '<grandchild baz="fizbuzz2">grandchild content2</grandchild>' +
                '</child>' +
                '<sibling>with content!</sibling>' +
            '</root>';
 
-var xmlDoc = libxmljs.parseXml(xml);
+var xmlDoc = libxml.parseXml(xml);
 
 // xpath queries
 var gchild = xmlDoc.get('//grandchild');
-
 console.log(gchild.text());  // prints "grandchild content"
+
+var gchildren = xmlDoc.find('//grandchild');
+gchildren.forEach(function(gchild) {
+    console.log(gchild.text());
+    // prints "grandchild content"
+    // prints "grandchild content2"
+});
 
 var children = xmlDoc.root().childNodes();
 var child = children[0];
-
 console.log(child.attr('foo').value()); // prints "bar"
 ```
 


### PR DESCRIPTION
This is important to document the `find()` method right in the front README, it took me some time to find out how to have a collection of elements through XPath. I was getting mad at the `get()` method, before finding the wiki being well documented. Moreover `childNodes()` is documented, so let's do the "equivalent" for XPath.

FYI I have documented a bit more how to use `find()` in https://github.com/libxmljs/libxmljs/wiki/Element#elementfindxpath-namespaces