### PR TITLE
Added encoding for toString() method

### DIFF
--- a/src/xml_document.cc
+++ b/src/xml_document.cc
@@ -177,6 +177,7 @@ NAN_METHOD(XmlDocument::ToString)
     assert(document);
 
     int options = 0;
+    const char *encoding = "UTF-8";
 
     if (info.Length() > 0) {
     if (info[0]->IsBoolean()) {
@@ -185,6 +186,13 @@ NAN_METHOD(XmlDocument::ToString)
         }
     } else if (info[0]->IsObject()) {
         v8::Local<v8::Object> obj = Nan::To<v8::Object>(info[0]).ToLocalChecked();
+
+        // choose encoding declaration
+        v8::Local<v8::Value> encodingOpt = Nan::Get(obj, Nan::New<v8::String>("encoding").ToLocalChecked()).ToLocalChecked();
+        if (encodingOpt->IsString()) {
+            std::string encoding_ = *Nan::Utf8String(encodingOpt);
+            encoding = encoding_.c_str();
+        }
 
         // drop the xml declaration
         if (Nan::Get(obj, Nan::New<v8::String>("declaration").ToLocalChecked()).ToLocalChecked()->IsFalse()) {
@@ -227,7 +235,7 @@ NAN_METHOD(XmlDocument::ToString)
     }
 
     xmlBuffer* buf = xmlBufferCreate();
-    xmlSaveCtxt* savectx = xmlSaveToBuffer(buf, "UTF-8", options);
+    xmlSaveCtxt* savectx = xmlSaveToBuffer(buf, encoding, options);
     xmlSaveTree(savectx, (xmlNode*)document->xml_obj);
     xmlSaveFlush(savectx);
     xmlSaveClose(savectx);

--- a/test/html_parser.js
+++ b/test/html_parser.js
@@ -140,5 +140,13 @@ module.exports.toString = function(assert) {
     assert.ok(doc.toString({ type: 'xml' }).indexOf('<?xml') > -1);
     assert.ok(doc.toString({ type: 'xhtml' }).indexOf('<?xml') > -1);
     assert.ok(doc.toString({ type: 'xml', selfCloseEmpty:true }).indexOf('<a/>') > -1);
+
+    doc = libxml.parseHtml("<a>Something&nbsp;with a space</a>");
+    assert.ok(doc.toString().indexOf('<?xml') === -1);
+    assert.ok(doc.toString({ type: 'xml' }).indexOf('<?xml') > -1);
+    assert.ok(doc.toString({ type: 'xhtml' }).indexOf('<?xml') > -1);
+    assert.ok(doc.toString({ type: 'xhtml' }).indexOf('&nbsp;') === -1);
+    assert.ok(doc.toString({ type: 'xhtml', encoding: 'HTML' }).indexOf('&nbsp;') > -1);
+    assert.ok(doc.toString({ type: 'xhtml', encoding: 'ASCII' }).indexOf('&#160;') > -1);
     assert.done();
 }


### PR DESCRIPTION
Need to specify the encoding as `HTML` to fix #398 

(See http://xmlsoft.org/encoding.html#Default)

This PR adds the ability to provide a `encoding` option to `toString()`.