### PR TITLE
Provide bindings for the Text Writer API

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -24,6 +24,7 @@
         'src/xml_syntax_error.cc',
         'src/xml_text.cc',
         'src/xml_pi.cc',
+        'src/xml_textwriter.cc',
         'src/xml_xpath_context.cc',
         'vendor/libxml/buf.c',
         'vendor/libxml/catalog.c',

--- a/index.js
+++ b/index.js
@@ -40,3 +40,5 @@ module.exports.SaxPushParser = sax_parser.SaxPushParser;
 module.exports.memoryUsage = bindings.xmlMemUsed;
 
 module.exports.nodeCount = bindings.xmlNodeCount;
+
+module.exports.TextWriter = require('./lib/textwriter.js');

--- a/lib/textwriter.js
+++ b/lib/textwriter.js
@@ -1,0 +1,200 @@
+var bindings = require('./bindings');
+
+/// Create a new TextWriter instance
+/// @constructor
+var TextWriter = function() {
+    var writer = new bindings.TextWriter();
+    writer._openMemory();
+    return writer;
+};
+
+TextWriter.prototype = bindings.TextWriter.prototype;
+
+/// Return the content of the output buffer.
+/// @return buffer content
+TextWriter.prototype.toString = function() {
+    return this._bufferContent();
+}
+
+/// Empty the memory buffer
+/// @return buffer content
+TextWriter.prototype.clear = function() {
+    this._bufferEmpty();
+}
+
+/// Return the content of the output buffer.
+/// @param {boolean} [clear] clear the buffer afterwards.
+TextWriter.prototype.outputMemory = function(clear) {
+    var result = this.toString();
+    if (clear || typeof clear === 'undefined') {
+        this.clear();
+    }
+    return result;
+}
+
+/// Write document preamble
+/// @param {string} [version] xml version, default 1.0
+/// @param {string} [encoding] the encoding, default undefined
+/// @param {string} [standalone] (yes or no), default undefined
+/// @return number of bytes written (may be 0 because of buffering)
+TextWriter.prototype.startDocument = function(version, encoding, standalone) {
+    var result;
+
+    if (typeof standalone === 'boolean') {
+        standalone = standalone ? "yes" : "no";
+    }
+
+    result = this._startDocument(version, encoding, standalone);
+
+    if (result === -1) {
+        throw new Error("Failed to start document");
+    }
+}
+
+/// Close all elements and end the document
+/// @return number of bytes written (may be 0 because of buffering)
+TextWriter.prototype.endDocument = function() {
+    var result;
+
+    result = this._endDocument();
+
+    if (result === -1) {
+        throw new Error("Failed to end document");
+    }
+
+    return result;
+}
+
+/// Start an element
+/// @param {string} [prefix] namespace prefix
+/// @param {string} name element local name
+/// @param {string} [namespaceURI] namespace URI or NULL
+/// @return number of bytes written (may be 0 because of buffering)
+TextWriter.prototype.startElementNS = function(prefix, name, namespaceURI) {
+    var result;
+
+    result = this._startElementNS(prefix, name, namespaceURI);
+
+    if (result === -1) {
+        throw new Error("Failed to start element");
+    }
+
+    return result;
+}
+
+/// End the current element
+/// @return number of bytes written (may be 0 because of buffering)
+TextWriter.prototype.endElement = function() {
+    var result;
+
+    result = this._endElement();
+
+    if (result === -1) {
+        throw new Error("Failed to end element");
+    }
+
+    return result;
+}
+
+/// Start an attribute
+/// @param {string} [prefix] namespace prefix
+/// @param {string} name local name
+/// @param {string} [namespaceURI] namespace URI or NULL
+/// @return number of bytes written (may be 0 because of buffering)
+TextWriter.prototype.startAttributeNS = function(prefix, name, namespaceURI) {
+    var result;
+
+    result = this._startAttributeNS(prefix, name, namespaceURI);
+
+    if (result === -1) {
+        throw new Error("Failed to start attribute");
+    }
+
+    return result;
+}
+
+/// End the current attribute
+/// @return number of bytes written (may be 0 because of buffering)
+TextWriter.prototype.endAttribute = function() {
+    var result;
+
+    result = this._endAttribute();
+
+    if (result === -1) {
+        throw new Error("Failed to end attribute");
+    }
+
+    return result;
+}
+
+/// Start a CDATA section
+/// @return number of bytes written (may be 0 because of buffering)
+TextWriter.prototype.startCdata = function() {
+    var result;
+
+    result = this._startCdata();
+
+    if (result === -1) {
+        throw new Error("Failed to start CDATA section");
+    }
+
+    return result;
+}
+
+/// End a CDATA section
+/// @return number of bytes written (may be 0 because of buffering)
+TextWriter.prototype.endCdata = function() {
+    var result;
+
+    result = this._endCdata();
+
+    if (result === -1) {
+        throw new Error("Failed to end CDATA section");
+    }
+
+    return result;
+}
+
+/// Start a comment
+/// @return number of bytes written (may be 0 because of buffering)
+TextWriter.prototype.startComment = function() {
+    var result;
+
+    result = this._startComment();
+
+    if (result === -1) {
+        throw new Error("Failed to start Comment section");
+    }
+
+    return result;
+}
+
+/// End a comment
+/// @return number of bytes written (may be 0 because of buffering)
+TextWriter.prototype.endComment = function() {
+    var result;
+
+    result = this._endComment();
+
+    if (result === -1) {
+        throw new Error("Failed to end Comment section");
+    }
+
+    return result;
+}
+
+/// Write text
+/// @return number of bytes written (may be 0 because of buffering)
+TextWriter.prototype.writeString = function(text) {
+    var result;
+
+    result = this._writeString(text);
+
+    if (result === -1) {
+        throw new Error("Failed to write string");
+    }
+
+    return result;
+}
+
+module.exports = TextWriter;

--- a/src/libxmljs.cc
+++ b/src/libxmljs.cc
@@ -9,6 +9,7 @@
 #include "xml_node.h"
 #include "xml_sax_parser.h"
 #include "xml_namespace.h"
+#include "xml_textwriter.h"
 
 namespace libxmljs {
 
@@ -255,6 +256,7 @@ NAN_MODULE_INIT(init)
 
       XmlDocument::Initialize(target);
       XmlSaxParser::Initialize(target);
+      XmlTextWriter::Initialize(target);
 
       Nan::Set(target, Nan::New<v8::String>("libxml_version").ToLocalChecked(),
                   Nan::New<v8::String>(LIBXML_DOTTED_VERSION).ToLocalChecked());

--- a/src/xml_textwriter.cc
+++ b/src/xml_textwriter.cc
@@ -1,0 +1,289 @@
+// Copyright 2011, Squish Tech, LLC.
+
+#include "libxmljs.h"
+#include "xml_textwriter.h"
+
+namespace libxmljs {
+
+XmlTextWriter::XmlTextWriter() {
+  textWriter = NULL;
+  writerBuffer = NULL;
+}
+
+XmlTextWriter::~XmlTextWriter() {
+  if (textWriter) {
+    xmlFreeTextWriter(textWriter);
+  }
+  if (writerBuffer) {
+    xmlBufferFree(writerBuffer);
+  }
+}
+
+NAN_METHOD(XmlTextWriter::NewTextWriter) {
+  Nan::HandleScope scope;
+  XmlTextWriter *writer = new XmlTextWriter();
+  writer->Wrap(info.Holder());
+
+  return info.GetReturnValue().Set(info.Holder());
+}
+
+NAN_METHOD(XmlTextWriter::OpenMemory) {
+  Nan::HandleScope scope;
+
+  XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
+
+  writer->writerBuffer = xmlBufferCreate();
+  if (!writer->writerBuffer) {
+    return Nan::ThrowError("Failed to create memory buffer");
+  }
+
+  writer->textWriter = xmlNewTextWriterMemory(writer->writerBuffer, 0);
+  if (!writer->textWriter) {
+    xmlBufferFree(writer->writerBuffer);
+    return Nan::ThrowError("Failed to create buffer writer");
+  }
+
+  return info.GetReturnValue().Set(Nan::Undefined());
+}
+
+NAN_METHOD(XmlTextWriter::BufferContent) {
+  Nan::HandleScope scope;
+
+  XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
+
+  // Flush the output buffer of the libxml writer instance in order to push all
+  // the content to our writerBuffer.
+  xmlTextWriterFlush(writer->textWriter);
+
+  // Receive bytes from the writerBuffer
+  const xmlChar *buf = xmlBufferContent(writer->writerBuffer);
+
+  return info.GetReturnValue().Set(Nan::New<v8::String>((const char*)buf,
+              xmlBufferLength(writer->writerBuffer)).ToLocalChecked());
+}
+
+NAN_METHOD(XmlTextWriter::BufferEmpty) {
+  Nan::HandleScope scope;
+
+  XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
+
+  // Flush the output buffer of the libxml writer instance in order to push all
+  // the content to our writerBuffer.
+  xmlTextWriterFlush(writer->textWriter);
+
+  // Clear the memory buffer
+  xmlBufferEmpty(writer->writerBuffer);
+
+  return info.GetReturnValue().Set(Nan::Undefined());
+}
+
+NAN_METHOD(XmlTextWriter::StartDocument) {
+  Nan::HandleScope scope;
+
+  XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
+
+  v8::String::Utf8Value version(info[0]->ToString());
+  v8::String::Utf8Value encoding(info[1]->ToString());
+  v8::String::Utf8Value standalone(info[2]->ToString());
+
+  int result = xmlTextWriterStartDocument(
+          writer->textWriter,
+          info[0]->IsUndefined() ? NULL : *version,
+          info[1]->IsUndefined() ? NULL : *encoding,
+          info[2]->IsUndefined() ? NULL : *standalone);
+
+  return info.GetReturnValue().Set(Nan::New<v8::Number>((double)result));
+}
+
+NAN_METHOD(XmlTextWriter::EndDocument) {
+  Nan::HandleScope scope;
+
+  XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
+
+  int result = xmlTextWriterEndDocument(writer->textWriter);
+
+  return info.GetReturnValue().Set(Nan::New<v8::Number>((double)result));
+}
+
+NAN_METHOD(XmlTextWriter::StartElementNS) {
+  Nan::HandleScope scope;
+
+  XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
+
+  v8::String::Utf8Value prefix(info[0]->ToString());
+  v8::String::Utf8Value name(info[1]->ToString());
+  v8::String::Utf8Value namespaceURI(info[2]->ToString());
+
+  int result = xmlTextWriterStartElementNS(
+          writer->textWriter,
+          info[0]->IsUndefined() ? NULL : (const xmlChar*)*prefix,
+          info[1]->IsUndefined() ? NULL : (const xmlChar*)*name,
+          info[2]->IsUndefined() ? NULL : (const xmlChar*)*namespaceURI);
+
+  return info.GetReturnValue().Set(Nan::New<v8::Number>((double)result));
+}
+
+NAN_METHOD(XmlTextWriter::EndElement) {
+  Nan::HandleScope scope;
+
+  XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
+
+  int result = xmlTextWriterEndElement(writer->textWriter);
+
+  return info.GetReturnValue().Set(Nan::New<v8::Number>((double)result));
+}
+
+NAN_METHOD(XmlTextWriter::StartAttributeNS) {
+  Nan::HandleScope scope;
+
+  XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
+
+  v8::String::Utf8Value prefix(info[0]->ToString());
+  v8::String::Utf8Value name(info[1]->ToString());
+  v8::String::Utf8Value namespaceURI(info[2]->ToString());
+
+  int result = xmlTextWriterStartAttributeNS(
+          writer->textWriter,
+          info[0]->IsUndefined() ? NULL : (const xmlChar*)*prefix,
+          info[1]->IsUndefined() ? NULL : (const xmlChar*)*name,
+          info[2]->IsUndefined() ? NULL : (const xmlChar*)*namespaceURI);
+
+  return info.GetReturnValue().Set(Nan::New<v8::Number>((double)result));
+}
+
+NAN_METHOD(XmlTextWriter::EndAttribute) {
+  Nan::HandleScope scope;
+
+  XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
+
+  int result = xmlTextWriterEndAttribute(writer->textWriter);
+
+  return info.GetReturnValue().Set(Nan::New<v8::Number>((double)result));
+}
+
+NAN_METHOD(XmlTextWriter::StartCdata) {
+  Nan::HandleScope scope;
+
+  XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
+
+  int result = xmlTextWriterStartCDATA(writer->textWriter);
+
+  return info.GetReturnValue().Set(Nan::New<v8::Number>((double)result));
+}
+
+NAN_METHOD(XmlTextWriter::EndCdata) {
+  Nan::HandleScope scope;
+
+  XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
+
+  int result = xmlTextWriterEndCDATA(writer->textWriter);
+
+  return info.GetReturnValue().Set(Nan::New<v8::Number>((double)result));
+}
+
+NAN_METHOD(XmlTextWriter::StartComment) {
+  Nan::HandleScope scope;
+
+  XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
+
+  int result = xmlTextWriterStartComment(writer->textWriter);
+
+  return info.GetReturnValue().Set(Nan::New<v8::Number>((double)result));
+}
+
+NAN_METHOD(XmlTextWriter::EndComment) {
+  Nan::HandleScope scope;
+
+  XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
+
+  int result = xmlTextWriterEndComment(writer->textWriter);
+
+  return info.GetReturnValue().Set(Nan::New<v8::Number>((double)result));
+}
+
+NAN_METHOD(XmlTextWriter::WriteString) {
+  Nan::HandleScope scope;
+
+  XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
+
+  v8::String::Utf8Value string(info[0]->ToString());
+
+  int result = xmlTextWriterWriteString(writer->textWriter,
+      (const xmlChar*)*string);
+
+  return info.GetReturnValue().Set(Nan::New<v8::Number>((double)result));
+}
+
+void
+XmlTextWriter::Initialize(v8::Handle<v8::Object> target) {
+  Nan::HandleScope scope;
+
+  v8::Local<v8::FunctionTemplate> writer_t =
+    Nan::New<v8::FunctionTemplate>(NewTextWriter);
+
+  Nan::Persistent<v8::FunctionTemplate> xml_writer_template;
+  xml_writer_template.Reset(writer_t);
+
+
+  writer_t->InstanceTemplate()->SetInternalFieldCount(1);
+
+  Nan::SetPrototypeMethod(writer_t,
+          "_openMemory",
+          XmlTextWriter::OpenMemory);
+
+  Nan::SetPrototypeMethod(writer_t,
+          "_bufferContent",
+          XmlTextWriter::BufferContent);
+
+  Nan::SetPrototypeMethod(writer_t,
+          "_bufferEmpty",
+          XmlTextWriter::BufferEmpty);
+
+  Nan::SetPrototypeMethod(writer_t,
+          "_startDocument",
+          XmlTextWriter::StartDocument);
+
+  Nan::SetPrototypeMethod(writer_t,
+          "_endDocument",
+          XmlTextWriter::EndDocument);
+
+  Nan::SetPrototypeMethod(writer_t,
+          "_startElementNS",
+          XmlTextWriter::StartElementNS);
+
+  Nan::SetPrototypeMethod(writer_t,
+          "_endElement",
+          XmlTextWriter::EndElement);
+
+  Nan::SetPrototypeMethod(writer_t,
+          "_startAttributeNS",
+          XmlTextWriter::StartAttributeNS);
+
+  Nan::SetPrototypeMethod(writer_t,
+          "_endAttribute",
+          XmlTextWriter::EndAttribute);
+
+  Nan::SetPrototypeMethod(writer_t,
+          "_startCdata",
+          XmlTextWriter::StartCdata);
+
+  Nan::SetPrototypeMethod(writer_t,
+          "_endCdata",
+          XmlTextWriter::EndCdata);
+
+  Nan::SetPrototypeMethod(writer_t,
+          "_startComment",
+          XmlTextWriter::StartComment);
+
+  Nan::SetPrototypeMethod(writer_t,
+          "_endComment",
+          XmlTextWriter::EndComment);
+
+  Nan::SetPrototypeMethod(writer_t,
+          "_writeString",
+          XmlTextWriter::WriteString);
+
+  Nan::Set(target, Nan::New<v8::String>("TextWriter").ToLocalChecked(),
+              writer_t->GetFunction());
+}
+}  // namespace libxmljs

--- a/src/xml_textwriter.cc
+++ b/src/xml_textwriter.cc
@@ -82,9 +82,9 @@ NAN_METHOD(XmlTextWriter::StartDocument) {
 
   XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
 
-  v8::String::Utf8Value version(info[0]->ToString());
-  v8::String::Utf8Value encoding(info[1]->ToString());
-  v8::String::Utf8Value standalone(info[2]->ToString());
+  Nan::Utf8String version(Nan::To<v8::String>(info[0]).ToLocalChecked());
+  Nan::Utf8String encoding(Nan::To<v8::String>(info[1]).ToLocalChecked());
+  Nan::Utf8String standalone(Nan::To<v8::String>(info[2]).ToLocalChecked());
 
   int result = xmlTextWriterStartDocument(
           writer->textWriter,
@@ -110,9 +110,9 @@ NAN_METHOD(XmlTextWriter::StartElementNS) {
 
   XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
 
-  v8::String::Utf8Value prefix(info[0]->ToString());
-  v8::String::Utf8Value name(info[1]->ToString());
-  v8::String::Utf8Value namespaceURI(info[2]->ToString());
+  Nan::Utf8String prefix(Nan::To<v8::String>(info[0]).ToLocalChecked());
+  Nan::Utf8String name(Nan::To<v8::String>(info[1]).ToLocalChecked());
+  Nan::Utf8String namespaceURI(Nan::To<v8::String>(info[2]).ToLocalChecked());
 
   int result = xmlTextWriterStartElementNS(
           writer->textWriter,
@@ -138,9 +138,9 @@ NAN_METHOD(XmlTextWriter::StartAttributeNS) {
 
   XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
 
-  v8::String::Utf8Value prefix(info[0]->ToString());
-  v8::String::Utf8Value name(info[1]->ToString());
-  v8::String::Utf8Value namespaceURI(info[2]->ToString());
+  Nan::Utf8String prefix(Nan::To<v8::String>(info[0]).ToLocalChecked());
+  Nan::Utf8String name(Nan::To<v8::String>(info[1]).ToLocalChecked());
+  Nan::Utf8String namespaceURI(Nan::To<v8::String>(info[2]).ToLocalChecked());
 
   int result = xmlTextWriterStartAttributeNS(
           writer->textWriter,
@@ -206,7 +206,7 @@ NAN_METHOD(XmlTextWriter::WriteString) {
 
   XmlTextWriter *writer = Nan::ObjectWrap::Unwrap<XmlTextWriter>(info.Holder());
 
-  v8::String::Utf8Value string(info[0]->ToString());
+  Nan::Utf8String string(Nan::To<v8::String>(info[0]).ToLocalChecked());
 
   int result = xmlTextWriterWriteString(writer->textWriter,
       (const xmlChar*)*string);
@@ -215,7 +215,7 @@ NAN_METHOD(XmlTextWriter::WriteString) {
 }
 
 void
-XmlTextWriter::Initialize(v8::Handle<v8::Object> target) {
+XmlTextWriter::Initialize(v8::Local<v8::Object> target) {
   Nan::HandleScope scope;
 
   v8::Local<v8::FunctionTemplate> writer_t =
@@ -284,6 +284,6 @@ XmlTextWriter::Initialize(v8::Handle<v8::Object> target) {
           XmlTextWriter::WriteString);
 
   Nan::Set(target, Nan::New<v8::String>("TextWriter").ToLocalChecked(),
-              writer_t->GetFunction());
+              Nan::GetFunction(writer_t).ToLocalChecked());
 }
 }  // namespace libxmljs

--- a/src/xml_textwriter.h
+++ b/src/xml_textwriter.h
@@ -1,0 +1,60 @@
+// Copyright 2009, Squish Tech, LLC.
+#ifndef SRC_XML_TEXTWRITER_H_
+#define SRC_XML_TEXTWRITER_H_
+
+#include <node.h>
+#include <libxml/xmlwriter.h>
+
+namespace libxmljs {
+
+class XmlTextWriter : public Nan::ObjectWrap {
+  public:
+
+  XmlTextWriter();
+  virtual ~XmlTextWriter();
+
+  static void
+  Initialize(v8::Handle<v8::Object> target);
+
+  static NAN_METHOD(NewTextWriter);
+
+  static NAN_METHOD(OpenMemory);
+
+  static NAN_METHOD(BufferContent);
+
+  static NAN_METHOD(BufferEmpty);
+
+  static NAN_METHOD(StartDocument);
+
+  static NAN_METHOD(EndDocument);
+
+  static NAN_METHOD(StartElementNS);
+
+  static NAN_METHOD(EndElement);
+
+  static NAN_METHOD(StartAttributeNS);
+
+  static NAN_METHOD(EndAttribute);
+
+  static NAN_METHOD(StartCdata);
+
+  static NAN_METHOD(EndCdata);
+
+  static NAN_METHOD(StartComment);
+
+  static NAN_METHOD(EndComment);
+
+  static NAN_METHOD(WriteString);
+
+
+  private:
+  xmlTextWriterPtr textWriter;
+  xmlBufferPtr  writerBuffer;
+
+  bool is_open();
+
+  bool is_inmemory();
+};
+}
+
+#endif  // SRC_XML_TEXTWRITER_H_

--- a/src/xml_textwriter.h
+++ b/src/xml_textwriter.h
@@ -14,7 +14,7 @@ class XmlTextWriter : public Nan::ObjectWrap {
   virtual ~XmlTextWriter();
 
   static void
-  Initialize(v8::Handle<v8::Object> target);
+  Initialize(v8::Local<v8::Object> target);
 
   static NAN_METHOD(NewTextWriter);
 

--- a/test/xml_textwriter.js
+++ b/test/xml_textwriter.js
@@ -1,0 +1,207 @@
+var libxml = require('../index');
+
+module.exports['should write an XML preamble to memory'] = function (test) {
+    var writer;
+    var count;
+    var output;
+
+    writer = new libxml.TextWriter();
+    count += writer.startDocument();
+    count += writer.endDocument();
+    output = writer.outputMemory();
+    test.equal('<?xml version="1.0"?>\n\n', output);
+
+    writer = new libxml.TextWriter();
+    count += writer.startDocument('1.0');
+    count += writer.endDocument();
+    output = writer.outputMemory();
+    test.equal('<?xml version="1.0"?>\n\n', output);
+
+    writer = new libxml.TextWriter();
+    count += writer.startDocument('1.0', 'UTF-8');
+    count += writer.endDocument();
+    output = writer.outputMemory();
+    test.equal('<?xml version="1.0" encoding="UTF-8"?>\n\n', output);
+
+    writer = new libxml.TextWriter();
+    count += writer.startDocument('1.0', 'UTF-8', 'yes');
+    count += writer.endDocument();
+    output = writer.outputMemory();
+    test.equal('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n\n', output);
+
+    test.done();
+};
+
+module.exports['should write elements without namespace'] = function (test) {
+    var writer = new libxml.TextWriter();
+    var count;
+    var output;
+
+    count += writer.startDocument('1.0', 'UTF-8');
+    count += writer.startElementNS(undefined, 'root');
+    count += writer.startElementNS(undefined, 'child');
+    count += writer.endElement();
+    count += writer.endElement();
+    count += writer.endDocument();
+    output = writer.outputMemory();
+
+    test.equal('<?xml version="1.0" encoding="UTF-8"?>\n<root><child/></root>\n', output);
+
+    test.done();
+};
+
+module.exports['should write elements with default namespace'] = function (test) {
+    var writer = new libxml.TextWriter();
+    var count;
+    var output;
+
+    count += writer.startDocument('1.0', 'UTF-8');
+    count += writer.startElementNS(undefined, 'html', 'http://www.w3.org/1999/xhtml');
+    count += writer.startElementNS(undefined, 'head');
+    count += writer.endElement();
+    count += writer.endElement();
+    count += writer.endDocument();
+    output = writer.outputMemory();
+
+    test.equal('<?xml version="1.0" encoding="UTF-8"?>\n<html xmlns="http://www.w3.org/1999/xhtml"><head/></html>\n', output);
+
+    test.done();
+};
+
+module.exports['should write elements with namespace prefix'] = function (test) {
+    var writer = new libxml.TextWriter();
+    var count;
+    var output;
+
+    count += writer.startDocument('1.0', 'UTF-8');
+    count += writer.startElementNS('html', 'html', 'http://www.w3.org/1999/xhtml');
+    count += writer.startElementNS('html', 'head');
+    count += writer.endElement();
+    count += writer.endElement();
+    count += writer.endDocument();
+    output = writer.outputMemory();
+
+    test.equal('<?xml version="1.0" encoding="UTF-8"?>\n<html:html xmlns:html="http://www.w3.org/1999/xhtml"><html:head/></html:html>\n', output);
+
+    test.done();
+};
+
+module.exports['should write attributes with default namespace'] = function (test) {
+    var writer = new libxml.TextWriter();
+    var count;
+    var output;
+
+    count += writer.startDocument('1.0', 'UTF-8');
+    count += writer.startElementNS(undefined, 'root', 'http://example.com');
+    count += writer.startAttributeNS(undefined, 'attr', 'http://example.com');
+    count += writer.writeString('value');
+    count += writer.endAttribute();
+    count += writer.endElement();
+    count += writer.endDocument();
+    output = writer.outputMemory();
+
+    test.equal('<?xml version="1.0" encoding="UTF-8"?>\n<root attr="value" xmlns="http://example.com"/>\n', output);
+
+    test.done();
+};
+
+module.exports['should write attributes with namespace prefix'] = function (test) {
+    var writer = new libxml.TextWriter();
+    var count;
+    var output;
+
+    count += writer.startDocument('1.0', 'UTF-8');
+    count += writer.startElementNS(undefined, 'root');
+    count += writer.startAttributeNS('pfx', 'attr', 'http://example.com');
+    count += writer.writeString('value');
+    count += writer.endAttribute();
+    count += writer.endElement();
+    count += writer.endDocument();
+    output = writer.outputMemory();
+
+    test.equal('<?xml version="1.0" encoding="UTF-8"?>\n<root pfx:attr="value" xmlns:pfx="http://example.com"/>\n', output);
+
+    test.done();
+};
+
+module.exports['should write text node'] = function (test) {
+    var writer = new libxml.TextWriter();
+    var count;
+    var output;
+
+    count += writer.startDocument('1.0', 'UTF-8');
+    count += writer.startElementNS(undefined, 'root');
+    count += writer.writeString('some text here');
+    count += writer.endElement();
+    count += writer.endDocument();
+    output = writer.outputMemory();
+
+    test.equal('<?xml version="1.0" encoding="UTF-8"?>\n<root>some text here</root>\n', output);
+
+    test.done();
+};
+
+module.exports['should write cdata section'] = function (test) {
+    var writer = new libxml.TextWriter();
+    var count;
+    var output;
+
+    count += writer.startDocument('1.0', 'UTF-8');
+    count += writer.startElementNS(undefined, 'root');
+    count += writer.startCdata();
+    count += writer.writeString('some text here');
+    count += writer.endCdata();
+    count += writer.endElement();
+    count += writer.endDocument();
+    output = writer.outputMemory();
+
+    test.equal('<?xml version="1.0" encoding="UTF-8"?>\n<root><![CDATA[some text here]]></root>\n', output);
+
+    test.done();
+};
+
+module.exports['should return the contents of the output buffer when told so'] = function(test) {
+    var writer = new libxml.TextWriter();
+    var count;
+    var output;
+
+    count += writer.startDocument();
+    count += writer.startElementNS(undefined, 'root');
+    output = writer.outputMemory();
+
+    test.equal('<?xml version="1.0"?>\n<root', output);
+
+    output = writer.outputMemory();
+    test.equal('', output);
+
+    count += writer.endElement();
+    count += writer.endDocument();
+
+    output = writer.outputMemory();
+    test.equal('/>\n', output);
+
+    test.done();
+};
+
+module.exports['should not flush the output buffer when told so'] = function(test) {
+    var writer = new libxml.TextWriter();
+    var count;
+    var output;
+
+    count += writer.startDocument();
+    count += writer.startElementNS(undefined, 'root');
+
+    // flush buffer=false, ...
+    output = writer.outputMemory(false);
+    test.equal('<?xml version="1.0"?>\n<root', output);
+
+    // content should be receivable here.
+    output = writer.outputMemory(true);
+    test.equal('<?xml version="1.0"?>\n<root', output);
+
+    // but not here anymore because of recent flush.
+    output = writer.outputMemory();
+    test.equal('', output);
+
+    test.done();
+};

--- a/vendor/libxml/include/libxml/xmlversion.h
+++ b/vendor/libxml/include/libxml/xmlversion.h
@@ -156,7 +156,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * Whether the xmlWriter saving interface is configured in
  */
-#if 0
+#if 1
 #define LIBXML_WRITER_ENABLED
 #endif
 


### PR DESCRIPTION
Support basic set of [xmlwriter](http://xmlsoft.org/html/libxml-xmlwriter.html) interface of libxml2. This PR has been proposed in #80 then migrated to #91 and was rejected in #104. Since then I've been maintaining this branch in my own repo. This is because [xmlshim](https://www.npmjs.com/package/xmlshim) depends on the xmlwriter API.

Now that libxmljs is providing binaries, maintenance of the fork has proven to be even more difficult than before :/