### PR TITLE
Fix appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,17 @@
 environment:
   npm_version: latest
-  gyp_version: latest
-  pre_gyp_version: latest
   github_release_token:
     secure: en/UnoFHA3RsSAHM5c6zb3RAMa4V01lC3pYG1YrHSeOPFu78SUA/0lOjNe3pp8RG
   matrix:
-    - nodejs_version: 0.10
-      npm_version: 4.0.3
-      gyp_version: 3.5.0
-      pre_gyp_version: 0.6.36
-    - nodejs_version: 0.12
-      npm_version: 4.0.3
-      gyp_version: 3.5.0
-      pre_gyp_version: 0.6.36
     - nodejs_version: 4
+      npm_version: 4.0.3
     - nodejs_version: 5
+      npm_version: 4.0.3
     - nodejs_version: 6
     - nodejs_version: 7
     - nodejs_version: 8
+    - nodejs_version: 9
+    - nodejs_version: 10
 
 platform:
   - x86
@@ -36,8 +30,7 @@ install:
   - npm config set python C:\Python27\python.exe
   - npm install -g npm@%npm_version%
   - npm --version
-  - npm install -g node-gyp@%gyp_version%
-  - npm install -g node-pre-gyp@%pre_gyp_version%
+  - npm install -g node-pre-gyp@0.6.37 --production
 
   # work around an issue with node-gyp v3.3.1 and node 4x
   # https://github.com/nodejs/node-gyp/issues/921

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
   },
   "description": "libxml bindings for v8 javascript engine",
-  "version": "0.18.8",
+  "version": "0.18.9-pre0",
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build --loglevel http",
     "test": "node --expose_gc ./node_modules/.bin/nodeunit test"
@@ -30,12 +30,12 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "bindings": "^1.3.0",
+    "bindings": "~1.3.0",
     "nan": "~2.10.0",
-    "node-pre-gyp": "^0.9.1"
+    "node-pre-gyp": "~0.6.37"
   },
   "devDependencies": {
-    "nodeunit": "^0.11.2",
-    "semver": "5.5.0"
+    "nodeunit": "~0.11.2",
+    "semver": "~5.5.0"
   }
 }


### PR DESCRIPTION
- remove node `0.10` and `0.12`
- add node 9, 10.
- downgrade `node-pre-gyp` to `0.6.37`
- use `~` for version to accept only patch update

i dont know what's the last good version of `node-pre-gyp` so i'm just going to use one in release `0.18.7`

Fixes: #509 #506 