### PR TITLE
Add libxml2 processing instructions support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -23,6 +23,7 @@
         'src/xml_sax_parser.cc',
         'src/xml_syntax_error.cc',
         'src/xml_text.cc',
+        'src/xml_pi.cc',
         'src/xml_xpath_context.cc',
         'vendor/libxml/buf.c',
         'vendor/libxml/catalog.c',

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports.features = bindings.features;
 module.exports.Comment = require('./lib/comment');
 module.exports.Document = Document;
 module.exports.Element = require('./lib/element');
+module.exports.ProcessingInstruction = require('./lib/pi');
 module.exports.Text = require('./lib/text');
 
 // Compatibility synonyms

--- a/lib/element.js
+++ b/lib/element.js
@@ -3,7 +3,7 @@ var bindings = require('./bindings');
 /// create a new element on the given document
 /// @param doc the Document to create the element for
 /// @param name the element name
-/// @param {String} [contenn] element content
+/// @param {String} [content] element content
 /// @constructor
 function Element(doc, name, content) {
     if (!doc) {

--- a/lib/pi.js
+++ b/lib/pi.js
@@ -1,0 +1,23 @@
+var bindings = require('./bindings');
+
+/// create a new processing instruction on the given document
+/// @param doc the Document to create the processing instruction for
+/// @param name the processing instruction name
+/// @param {String} [content] processing instruction content
+/// @constructor
+function ProcessingInstruction(doc, name, content) {
+    if (!doc) {
+        throw new Error('document argument required');
+    } else if (! (doc instanceof bindings.Document)) {
+        throw new Error('document argument must be an ' +
+                        'instance of Document');
+    } else if (!name) {
+        throw new Error('name argument required');
+    }
+
+    return new bindings.ProcessingInstruction(doc, name, content);
+}
+
+ProcessingInstruction.prototype = bindings.ProcessingInstruction.prototype;
+
+module.exports = ProcessingInstruction;

--- a/src/xml_node.cc
+++ b/src/xml_node.cc
@@ -11,6 +11,7 @@
 #include "xml_comment.h"
 #include "xml_text.h"
 #include "xml_attribute.h"
+#include "xml_pi.h"
 
 namespace libxmljs {
 
@@ -781,6 +782,7 @@ XmlNode::Initialize(v8::Handle<v8::Object> target) {
   XmlElement::Initialize(target);
   XmlText::Initialize(target);
   XmlComment::Initialize(target);
+  XmlProcessingInstruction::Initialize(target);
   XmlAttribute::Initialize(target);
 }
 }  // namespace libxmljs

--- a/src/xml_pi.cc
+++ b/src/xml_pi.cc
@@ -1,0 +1,148 @@
+#include <node.h>
+
+#include <cstring>
+
+#include "libxmljs.h"
+
+#include "xml_pi.h"
+#include "xml_document.h"
+#include "xml_attribute.h"
+#include "xml_xpath_context.h"
+
+namespace libxmljs {
+
+Nan::Persistent<v8::FunctionTemplate> XmlProcessingInstruction::constructor_template;
+
+// doc, content
+NAN_METHOD(XmlProcessingInstruction::New) {
+  Nan::HandleScope scope;
+
+  // if we were created for an existing xml node, then we don't need
+  // to create a new node on the document
+  if (info.Length() == 0) {
+      return info.GetReturnValue().Set(info.Holder());
+  }
+
+  XmlDocument* document = Nan::ObjectWrap::Unwrap<XmlDocument>(info[0]->ToObject());
+  assert(document);
+
+  v8::String::Utf8Value name(info[1]);
+
+  v8::Local<v8::Value> contentOpt;
+  if (info[2]->IsString()) {
+      contentOpt = info[2];
+  }
+  v8::String::Utf8Value contentRaw(contentOpt);
+  const char* content = (contentRaw.length()) ? *contentRaw : NULL;
+
+  xmlNode* pi = xmlNewDocPI(document->xml_obj, (const xmlChar *) *name, (xmlChar *) content);
+
+  XmlProcessingInstruction* processing_instruction = new XmlProcessingInstruction(pi);
+  pi->_private = processing_instruction;
+  processing_instruction->Wrap(info.Holder());
+
+  // this prevents the document from going away
+  info.Holder()->Set(Nan::New<v8::String>("document").ToLocalChecked(), info[0]);
+
+  return info.GetReturnValue().Set(info.Holder());
+}
+
+NAN_METHOD(XmlProcessingInstruction::Name) {
+  Nan::HandleScope scope;
+  XmlProcessingInstruction *processing_instruction = Nan::ObjectWrap::Unwrap<XmlProcessingInstruction>(info.Holder());
+  assert(processing_instruction);
+
+  if (info.Length() == 0)
+      return info.GetReturnValue().Set(processing_instruction->get_name());
+
+  v8::String::Utf8Value name(info[0]->ToString());
+  processing_instruction->set_name(*name);
+  return info.GetReturnValue().Set(info.Holder());
+}
+
+NAN_METHOD(XmlProcessingInstruction::Text) {
+  Nan::HandleScope scope;
+  XmlProcessingInstruction *processing_instruction = Nan::ObjectWrap::Unwrap<XmlProcessingInstruction>(info.Holder());
+  assert(processing_instruction);
+
+  if (info.Length() == 0) {
+    return info.GetReturnValue().Set(processing_instruction->get_content());
+  } else {
+    processing_instruction->set_content(*v8::String::Utf8Value(info[0]));
+  }
+
+  return info.GetReturnValue().Set(info.Holder());
+}
+
+void
+XmlProcessingInstruction::set_name(const char* name) {
+  xmlNodeSetName(xml_obj, (const xmlChar*)name);
+}
+
+v8::Local<v8::Value>
+XmlProcessingInstruction::get_name() {
+    Nan::EscapableHandleScope scope;
+    if(xml_obj->name) return scope.Escape(Nan::New<v8::String>((const char*)xml_obj->name).ToLocalChecked());
+    else return scope.Escape(Nan::Undefined());
+}
+
+void
+XmlProcessingInstruction::set_content(const char* content) {
+  xmlNodeSetContent(xml_obj, (xmlChar*) content);
+}
+
+v8::Local<v8::Value>
+XmlProcessingInstruction::get_content() {
+  Nan::EscapableHandleScope scope;
+  xmlChar* content = xmlNodeGetContent(xml_obj);
+  if (content) {
+    v8::Local<v8::String> ret_content =
+      Nan::New<v8::String>((const char *)content).ToLocalChecked();
+    xmlFree(content);
+    return scope.Escape(ret_content);
+  }
+
+  return scope.Escape(Nan::New<v8::String>("").ToLocalChecked());
+}
+
+v8::Local<v8::Object>
+XmlProcessingInstruction::New(xmlNode* node)
+{
+    Nan::EscapableHandleScope scope;
+    if (node->_private) {
+        return scope.Escape(static_cast<XmlNode*>(node->_private)->handle());
+    }
+
+    XmlProcessingInstruction* processing_instruction = new XmlProcessingInstruction(node);
+    v8::Local<v8::Object> obj = Nan::NewInstance(Nan::New(constructor_template)->GetFunction()).ToLocalChecked();
+    processing_instruction->Wrap(obj);
+    return scope.Escape(obj);
+}
+
+XmlProcessingInstruction::XmlProcessingInstruction(xmlNode* node)
+    : XmlNode(node)
+{
+}
+
+void
+XmlProcessingInstruction::Initialize(v8::Handle<v8::Object> target)
+{
+    Nan::HandleScope scope;
+    v8::Local<v8::FunctionTemplate> t = Nan::New<v8::FunctionTemplate>(static_cast<NAN_METHOD((*))>(New));
+    t->Inherit(Nan::New(XmlNode::constructor_template));
+    t->InstanceTemplate()->SetInternalFieldCount(1);
+    constructor_template.Reset( t);
+
+    Nan::SetPrototypeMethod(t,
+            "name",
+            XmlProcessingInstruction::Name);
+
+    Nan::SetPrototypeMethod(t,
+            "text",
+            XmlProcessingInstruction::Text);
+
+    Nan::Set(target, Nan::New<v8::String>("ProcessingInstruction").ToLocalChecked(),
+            t->GetFunction());
+}
+
+}  // namespace libxmljs

--- a/src/xml_pi.h
+++ b/src/xml_pi.h
@@ -1,0 +1,36 @@
+#ifndef SRC_XML_PI_H_
+#define SRC_XML_PI_H_
+
+#include "libxmljs.h"
+#include "xml_node.h"
+
+namespace libxmljs {
+
+class XmlProcessingInstruction : public XmlNode {
+public:
+
+    explicit XmlProcessingInstruction(xmlNode* node);
+
+    static void Initialize(v8::Handle<v8::Object> target);
+
+    static Nan::Persistent<v8::FunctionTemplate> constructor_template;
+
+    // create new xml comment to wrap the node
+    static v8::Local<v8::Object> New(xmlNode* node);
+
+protected:
+
+    static NAN_METHOD(New);
+    static NAN_METHOD(Name);
+    static NAN_METHOD(Text);
+
+    void set_name(const char* name);
+
+    v8::Local<v8::Value> get_name();
+    void set_content(const char* content);
+    v8::Local<v8::Value> get_content();
+};
+
+}  // namespace libxmljs
+
+#endif  // SRC_XML_PI_H_

--- a/test/pi.js
+++ b/test/pi.js
@@ -1,0 +1,29 @@
+var libxml = require('../index');
+
+module.exports.new = function(assert) {
+    var doc = libxml.Document();
+    var pi = libxml.ProcessingInstruction(doc, 'mypi', 'mycontent');
+    doc.root(new libxml.Element(doc, 'myelem'));
+    doc.root().addPrevSibling(pi);
+
+    assert.equal(doc.root().prevSibling(), pi);
+    assert.equal('mypi', pi.name());
+    assert.equal('mycontent', pi.text());
+    assert.done();
+};
+
+module.exports.name = function(assert) {
+    var doc = libxml.Document();
+    var pi = libxml.ProcessingInstruction(doc, 'mypi');
+    pi.name('mynewpi');
+    assert.equal('mynewpi', pi.name());
+    assert.done();
+};
+
+module.exports.text = function(assert) {
+    var doc = libxml.Document();
+    var pi = libxml.ProcessingInstruction(doc, 'mypi');
+    pi.text('pi3');
+    assert.equal('pi3', pi.text());
+    assert.done();
+};


### PR DESCRIPTION
Added a bridge to `xmlNewDocPI` for the ability of inserting and manipulating xml processing instructions. 
Closes #515

Adds a new `ProcessingInstruction` top level export class, which shares most of its implementation with the `Comment` class. The only difference is that the ProcessingInstruction also has a `name` attribute

Usage examples:

1) Adds a processing instruction before the root node

```js
const libxmljs = require('libxmljs');

var xml =  '<?xml version="1.0" encoding="UTF-8"?>' +
           '<root>' +
               '<child foo="bar">' +
                   '<grandchild baz="fizbuzz">grandchild content</grandchild>' +
               '</child>' +
               '<sibling>with content!</sibling>' +
           '</root>';

var xmlDoc = libxmljs.parseXml(xml);
var pi = libxmljs.ProcessingInstruction(xmlDoc, 'mypi', 'mycontent');
xmlDoc.root().addPrevSibling(pi);
console.log(xmlDoc.toString());
/*
<?xml version="1.0" encoding="UTF-8"?>
<?mypi mycontent?>
<root>
  <child foo="bar">
    <grandchild baz="fizbuzz">grandchild content</grandchild>
  </child>
  <sibling>with content!</sibling>
</root>
*/
```

2) `ProcessingInstruction` is a node, so it can be manipulated like any other node, in this case, changing the contents:

```js
const libxmljs = require('libxmljs');

var xml =  '<?xml version="1.0" encoding="UTF-8"?>' +
           '<?mypi mycontent?>' +
           '<root>' +
               '<child foo="bar">' +
                   '<grandchild baz="fizbuzz">grandchild content</grandchild>' +
               '</child>' +
               '<sibling>with content!</sibling>' +
           '</root>';

var xmlDoc = libxmljs.parseXml(xml);
console.log(xmlDoc.root().prevSibling().text()); // mycontent
xmlDoc.root().prevSibling().text('mynewcontent');
console.log(xmlDoc.root().prevSibling().text()); // mynewcontent
```

Need to update the wiki