### PR TITLE
Update node-pre-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "bindings": "~1.3.0",
     "nan": "~2.10.0",
-    "node-pre-gyp": "~0.10.2"
+    "node-pre-gyp": "~0.11.0"
   },
   "devDependencies": {
     "nodeunit": "~0.11.2",


### PR DESCRIPTION
After upgrade to libxmljs v0.19.1 some users (#511 and #506) have troubles with compilation under Node.js 10.

libxmljs v0.19.1 have one change - bump node-pre-gyp. But in node-pre-gyp v0.10.x was bug, that was fixed in v0.11.0.

This commit should fix any installation problems (works for me). Anyway node-pre-gyp must be upgraded.

P.S. I use [renovate](https://github.com/marketplace/renovate) to automatically update dependencies (it is free for open source, just try it :smile:)
