### PR TITLE
Add XInclude support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ sudo: false
 before_install:
 - if [[ $TRAVIS_OS_NAME == "osx" ]]; then export CXX=clang; fi
 # related: https://github.com/travis-ci/travis-ci/issues/6307#issuecomment-350725425
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; command curl -sSL https://rvm.io/mpapis.asc | gpg --import -; then rvm get stable; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; command curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -; then rvm get stable; fi
 - $CXX --version
 
 - PUBLISH_BINARY=false

--- a/binding.gyp
+++ b/binding.gyp
@@ -12,6 +12,7 @@
       'xcode_settings': {
         'OTHER_CFLAGS': [ '-Wall' ]
       },
+      'defines': ['LIBXML_XINCLUDE_ENABLED'],
       'sources': [
         'src/libxmljs.cc',
         'src/xml_attribute.cc',

--- a/src/xml_document.cc
+++ b/src/xml_document.cc
@@ -11,6 +11,7 @@
 #include <libxml/xmlschemas.h>
 #include <libxml/relaxng.h>
 #include <libxml/xmlsave.h>
+#include <libxml/xinclude.h>
 
 #include "xml_document.h"
 #include "xml_element.h"
@@ -459,6 +460,21 @@ NAN_METHOD(XmlDocument::FromXml)
             return Nan::ThrowError(XmlSyntaxError::BuildSyntaxError(error));
         }
         return Nan::ThrowError("Could not parse XML string");
+    }
+
+    if (opts & XML_PARSE_XINCLUDE) {
+        xmlSetStructuredErrorFunc(reinterpret_cast<void *>(&errors),
+                                  XmlSyntaxError::PushToArray);
+        int ret = xmlXIncludeProcessFlags(doc, opts);
+        xmlSetStructuredErrorFunc(NULL, NULL);
+
+        if (ret < 0) {
+            xmlError* error = xmlGetLastError();
+            if (error) {
+                return Nan::ThrowError(XmlSyntaxError::BuildSyntaxError(error));
+            }
+           return Nan::ThrowError("Could not perform XInclude substitution");
+        }
     }
 
     v8::Local<v8::Object> doc_handle = XmlDocument::New(doc);

--- a/test/fixtures/test.txt
+++ b/test/fixtures/test.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet

--- a/test/xinclude.js
+++ b/test/xinclude.js
@@ -1,0 +1,75 @@
+var libxml = require('../index');
+var path = require('path');
+
+var xml = '<?xml version="1.0" encoding="UTF-8"?>\n<root xmlns:xi="http://www.w3.org/2001/XInclude"><xi:include href="fixtures/parser.xml" /></root>';
+var txt = '<?xml version="1.0" encoding="UTF-8"?>\n<root xmlns:xi="http://www.w3.org/2001/XInclude"><xi:include href="fixtures/test.txt" parse="text" /></root>';
+
+var baseUrl = path.resolve(__dirname) + '/';
+var wrongBaseUrl = path.resolve(__dirname, 'fixtures') + '/';
+
+module.exports.xinclude = function(assert) {
+    var doc = libxml.parseXmlString(xml, {
+        baseUrl: baseUrl,
+        xinclude: true,
+        noxincnode: true
+    });        
+    const child = doc.get('//child');
+    assert.ok(child);
+    assert.equals('child', child.name());
+    assert.done();
+}
+
+module.exports.xincnode = function(assert) {
+    var doc = libxml.parseXmlString(xml, {
+        baseUrl: baseUrl,
+        xinclude: true,
+        noxincnode: false
+    });        
+    const xincnode = doc.root().child(0);
+    assert.ok(xincnode);
+    assert.equals('include', xincnode.name());
+    assert.equals('xinclude_start', xincnode.type());
+    assert.done();
+}
+
+module.exports.xincludeText = function(assert) {
+    var doc = libxml.parseXmlString(txt, {
+        baseUrl: baseUrl,
+        xinclude: true,
+        noxincnode: true
+    });    
+    assert.equals('Lorem ipsum dolor sit amet', doc.root().text());    
+    assert.done();
+}
+
+module.exports.xincludeDisabled = function(assert) {
+    var doc = libxml.parseXmlString(xml, {
+        baseUrl: baseUrl,        
+    });      
+    var include = doc.get('//xi:include', {xi: 'http://www.w3.org/2001/XInclude'});
+    assert.ok(include);
+    assert.done();
+}
+
+module.exports.wrongBaseUrl = function(assert) {
+    assert.throws(function() {
+        libxml.parseXmlString(xml, {
+            baseUrl: wrongBaseUrl,
+            xinclude: true,
+            noxincnode: true
+        });
+    }, /could not load.*and no fallback was found/);       
+    assert.done();
+}
+
+module.exports.wrongFileType = function(assert) {
+    var invalidXml = '<?xml version="1.0" encoding="UTF-8"?>\n<root xmlns:xi="http://www.w3.org/2001/XInclude"><xi:include href="fixtures/test.txt" /></root>'
+    assert.throws(function() {
+        libxml.parseXmlString(invalidXml, {
+            baseUrl: baseUrl,
+            xinclude: true,
+            noxincnode: true
+        });
+    }, /could not load.*and no fallback was found/);       
+    assert.done();
+}


### PR DESCRIPTION
- Perform XInclude substitution in parseXml if the xinclude option
  is set to true. Before this, the option was effectively a no-op.