### PR TITLE
add coverage test with badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 build/
 node_modules/
 npm-debug.log
+coverage
+.coveralls.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ node_js:
 - 9
 - 10
 
+after_success: 'npm run coveralls'
+
 addons:
   apt:
     sources:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/cf862a98w7qsajpl/branch/master?svg=true)](https://ci.appveyor.com/project/rchipka/libxmljs/branch/master)
 
+[![Coverage Status](https://coveralls.io/repos/hjadoui/libxmljs/badge.svg?branch=master)](https://coveralls.io/r/hjadoui/libxmljs?branch=master)
+
 LibXML bindings for [node.js](http://nodejs.org/)
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   "version": "0.19.5",
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build --loglevel http",
-    "test": "node --expose_gc ./node_modules/.bin/nodeunit test"
+    "test": "node --expose_gc ./node_modules/.bin/nodeunit test",
+    "coverage": "node node_modules/.bin/istanbul cover _mocha -- -R spec",
+    "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"
   },
   "repository": {
     "type": "git",
@@ -35,6 +37,9 @@
     "node-pre-gyp": "~0.11.0"
   },
   "devDependencies": {
+    "coveralls": "3.0.3",
+    "istanbul": "0.4.5",
+    "mocha": "6.0.2",
     "nodeunit": "~0.11.2",
     "semver": "~5.5.0"
   }


### PR DESCRIPTION
Hello,

I added coverage test with badge on the project repository, you have just to do a quick changes to integrate it with your account (the original project):

-create an account in coveralls and travis
-add your token in the file .coveralls.yml (create it locally) like this : 
              repo_token: PASTE_YOUR_TOKEN_HERE
-finally change the coverage status link in readme.md with the project account:
              Coverage Status](https://coveralls.io/repos/[PROJECT_ACCOUNT]/libxmljs/badge.svg?branch=master)](https://coveralls.io/r/[PROJECT_ACCOUNT]/libxmljs?branch=master)"



