### PR TITLE
Update array check

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -62,7 +62,7 @@ Element.prototype.cdata = function(content) {
 
 Element.prototype.get = function() {
     var res = this.find.apply(this, arguments);
-    if (res instanceof Array) {
+    if (Array.isArray(res)) {
         return res[0];
     } else {
         return res;


### PR DESCRIPTION
`instanceof` can be misleading at times. Specifically, when dealing with
arrays created in different contexts, the array Prototype will be
different allowing an array to be returned from `.get` calls.

This change uses `Array.isArray` as suggested by #566.

Closes #566