### PR TITLE
Adjust the version of the c++ standard libraries used to build on Mac.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -69,7 +69,7 @@
           # node-gyp 2.x doesn't add this anymore
           # https://github.com/TooTallNate/node-gyp/pull/612
           'xcode_settings': {
-            'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
+            'CLANG_CXX_LANGUAGE_STANDARD': 'c++17',
             'OTHER_LDFLAGS': [
               '-undefined dynamic_lookup'
             ],


### PR DESCRIPTION
This fixes the build on Node 16 on Macs. It works in my limited testing, but someone who knows more about this needs to sanity check the solution.

This aims to solve the following issue: https://github.com/libxmljs/libxmljs/issues/592