### PR TITLE
Update nan package to allow installation Macbook M1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.9",
     "bindings": "~1.3.0",
-    "nan": "~2.14.0"
+    "nan": "~2.17.0"
   },
   "devDependencies": {
     "nodeunit": "~0.11.2",


### PR DESCRIPTION
This PR fixes an issue that prevented me to install libxmljs on my Macbook m1. It bumps the version of nan.

Here is the error: 
```
npm ERR! In file included from ../../nan/nan.h:176:
npm ERR! ../../nan/nan_callbacks.h:55:23: error: no member named 'AccessorSignature' in namespace 'v8'
npm ERR! typedef v8::Local<v8::AccessorSignature> Sig;
npm ERR!                   ~~~~^
npm ERR! In file included from ../src/libxmljs.cc:7:
npm ERR! In file included from ../src/libxmljs.h:7:
npm ERR! ../../nan/nan.h:2542:8: error: no matching member function for call to 'SetAccessor'
npm ERR!   tpl->SetAccessor(
npm ERR!   ~~~~~^~~~~~~~~~~
npm ERR! /Users/snorberhuis/Library/Caches/node-gyp/19.2.0/include/node/v8-template.h:814:8: note: candidate function not viable: no known conversion from 'imp::Sig' (aka 'int') to 'v8::SideEffectType' for 7th argument
npm ERR!   void SetAccessor(
npm ERR!        ^
npm ERR! /Users/snorberhuis/Library/Caches/node-gyp/19.2.0/include/node/v8-template.h:807:8: note: candidate function not viable: no known conversion from 'imp::NativeGetter' (aka 'void (*)(v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Value> &)') to 'v8::AccessorGetterCallback' (aka 'void (*)(Local<v8::String>, const PropertyCallbackInfo<v8::Value> &)') for 2nd argument
npm ERR!   void SetAccessor(
npm ERR!        ^
npm ERR! 2 errors generated.
```
I found the solution here: https://github.com/nodejs/nan/issues/942