### PR TITLE
Reduce size of tgz by excluding parts of vendor we don't need

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,15 @@ docs/
 src/*.i
 swig.xml
 .github/
+
+# Parts of libxml we don't need
+vendor/libxml2/ChangeLog
+vendor/libxml2/CONTRIBUTING
+vendor/libxml2/doc
+vendor/libxml2/example
+vendor/libxml2/fuzz
+vendor/libxml2/NEWS
+vendor/libxml2/README.*
+vendor/libxml2/result
+vendor/libxml2/test
+vendor/libxml2/TODO*


### PR DESCRIPTION
This change reduces the size of the package from 5.6MB (42MB unpacked) to 2.4MB (17.4MB unpacked).

This was tested to not break #614 by building the package with `npm pack` and then installing it in a different (dummy) project with `npm install --build-from-source /path/to/libxmljs-1.0.6.tgz`.

Fixes #616