### PR TITLE
Fix Document.fromXmlAsync

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -14,8 +14,8 @@ Document.fromXml = (buffer: string | Buffer, options?: XMLParseOptions) => {
     return XMLDocument.fromXml(buffer, options);
 };
 
-Document.fromXmlAsync = (buffer: string | Buffer, options: HTMLParseOptions) => {
-    return XMLDocument.fromHtmlAsync(buffer, options);
+Document.fromXmlAsync = (buffer: string | Buffer, options: XMLParseOptions) => {
+    return XMLDocument.fromXmlAsync(buffer, options);
 };
 
 Document.fromHtml = (buffer: string | Buffer, options?: HTMLParseOptions): HTMLDocument => {

--- a/test/document.ts
+++ b/test/document.ts
@@ -378,6 +378,33 @@ module.exports.fromHtmlFragment = function (assert: any) {
     assert.done();
 };
 
+module.exports.fromXml = function (assert: any) {
+    var xml =
+        '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<!DOCTYPE type [<!ENTITY ent "entity">]>' +
+        '<root><node1>&ent;</node1><node2>node2</node2></root>';
+
+    var parsedXml = libxml.Document.fromXml(xml);
+    var node: any = parsedXml?.get('//node1');
+    var text = node.text();
+    assert.equal(text, 'entity');
+    assert.done();
+};
+
+module.exports.fromXmlAsync = function (assert: any) {
+    var xml =
+        '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<!DOCTYPE type [<!ENTITY ent "entity">]>' +
+        '<root><node1>&ent;</node1><node2>node2</node2></root>';
+
+    libxml.Document.fromXmlAsync(xml, {flags: [libxml.XMLParseFlags.XML_PARSE_NOENT]}).then(parsedXml => {
+        var node: any = parsedXml?.get('//node1');
+        var text = node.text();
+        assert.equal(text, 'entity');
+        assert.done();
+    });
+};
+
 module.exports.validate_rng_memory_usage = function (assert: any) {
     var rng =
         '<element name="addressBook" xmlns="http://relaxng.org/ns/structure/1.0">' +


### PR DESCRIPTION
`Document.fromXmlAsync` calls `fromHtmlAsync` instead of delegating to the proper `fromXmlAsync`.

This PR fixes the function declaration (which wrongly refers to `HTMLParseOptions`) and the implementation and adds a test for it.

Fixes #618