### PR TITLE
Fix resolving flags in the parseBufferAsync method

### DIFF
--- a/lib/document.ts
+++ b/lib/document.ts
@@ -420,6 +420,10 @@ export class XMLDocument extends XMLReference<xmlDocPtr> {
         return _ref.encoding || "";
     }
 
+    public getParseFlags(): number {
+        return this.getNativeReference().parseFlags;
+    }
+
     public type(): string {
         return "document";
     }

--- a/test/xml_parser.ts
+++ b/test/xml_parser.ts
@@ -21,6 +21,15 @@ module.exports.parse = function (assert: any) {
     assert.done();
 };
 
+module.exports.parse_with_flags = function (assert: any) {
+    const filename = __dirname + "/../../test/fixtures/parser.xml";
+    const str = fs.readFileSync(filename, "utf8").replace(/[\r]+/g, '');
+
+    const doc = libxml.parseXml(str, {replaceEntities: true, validateEntities: true});
+    assert.equal(18, doc.getParseFlags());
+    assert.done();
+}
+
 module.exports.parseAsync = function (assert: any) {
     var filename = __dirname + "/../../test/fixtures/parser.xml";
     var str = fs.readFileSync(filename, "utf8").replace(/[\r]+/g, '');
@@ -45,6 +54,19 @@ module.exports.parseAsync = function (assert: any) {
 
     assert.equal(++x, 1);
 };
+
+module.exports.parse_async_with_replace = function (assert: any) {
+    const filename = __dirname + "/../../test/fixtures/parser.xml";
+    const str = fs.readFileSync(filename, "utf8").replace(/[\r]+/g, '');
+
+    let x = 0;
+
+    libxml.parseXmlAsync(str, {replaceEntities: true, validateEntities: true}).then((doc) => {
+        assert.equal(18, doc.getParseFlags());
+        assert.done();
+    });
+    assert.equal(++x, 1);
+}
 
 module.exports.parse_buffer = function (assert: any) {
     var filename = __dirname + "/../../test/fixtures/parser-utf16.xml";


### PR DESCRIPTION
The options that were passed to the `parseXmlAsync` method were not used to create the correct flags.

The XML or HTML options were not being processed in the parseBufferAsync method as they were in the `parseXml` or `parseHtml` methods.

Added a new method that resolves the options by the `FROM_BUFFER_ASYNC_TYPE`.