### PR TITLE
chore: add build steps for node 20

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -7,7 +7,7 @@ on:
     workflow_dispatch:
 
 jobs:
-    upload:
+    upload-macos:
         strategy:
             fail-fast: false
             matrix:
@@ -23,8 +23,50 @@ jobs:
                     - { node-version: 16, npm-version: 8 }
                     - { node-version: 17, npm-version: 8 }
                     - { node-version: 18, npm-version: 8 }
-                os: [macos-latest, windows-2019]
-        runs-on: ${{ matrix.os }}
+                    - { node-version: 20, npm-version: 10 }
+        runs-on: macos-latest
+        steps:
+            - uses: actions/checkout@master
+              with:
+                  fetch-depth: 1
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: ${{ matrix.config.node-version }}
+                  registry-url: https://registry.npmjs.org
+
+            - name: Package prebuilt binary
+              run: |
+                  npm install -g npm@${{ matrix.config.npm-version }}
+                  npm config set progress false
+                  npm install --build-from-source
+                  npm run package 2>&1
+                  npm run tsc
+                  npm run test
+            - name: Upload release binary
+              uses: alexellis/upload-assets@0.3.0
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              with:
+                  asset_paths: '["./build/stage/libxmljs/libxmljs/releases/download/**/*.tar.gz"]'
+
+    upload-windows:
+        strategy:
+            fail-fast: false
+            matrix:
+                config:
+                    - { node-version: 8, npm-version: 6 }
+                    - { node-version: 9, npm-version: 6 }
+                    - { node-version: 10, npm-version: 6 }
+                    - { node-version: 11, npm-version: 6 }
+                    - { node-version: 12, npm-version: 8 }
+                    - { node-version: 13, npm-version: 8 }
+                    - { node-version: 14, npm-version: 8 }
+                    - { node-version: 15, npm-version: 8 }
+                    - { node-version: 16, npm-version: 8 }
+                    - { node-version: 17, npm-version: 8 }
+                    - { node-version: 18, npm-version: 8 }
+                    - { node-version: 20, npm-version: 10 }
+        runs-on: windows-2019
         steps:
             - uses: actions/checkout@master
               with:
@@ -39,7 +81,6 @@ jobs:
                   npm install -g npm@${{ matrix.config.npm-version }}
                   npm config set msvs_version "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise" --global
                   npm config set progress false
-                  npm config set spin false
                   npm install --build-from-source
                   npm run package 2>&1
                   npm run tsc
@@ -100,6 +141,7 @@ jobs:
                     - { node-version: 16 }
                     - { node-version: 17 }
                     - { node-version: 18 }
+                    - { node-version: 20 }
                 container-image: [x86_64]
         container:
             image: quay.io/pypa/manylinux_2_28_${{ matrix.container-image }}
@@ -145,6 +187,7 @@ jobs:
                     - { node-version: 16, npm-version: 8 }
                     - { node-version: 17, npm-version: 8 }
                     - { node-version: 18, npm-version: 8 }
+                    - { node-version: 20, npm-version: 10 }
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master
@@ -181,7 +224,6 @@ jobs:
                   run: |
                       source ~/.nvm/nvm.sh
                       npm config set progress false
-                      npm config set spin false
                       npm i @mapbox/node-pre-gyp node-gyp -g
                       chown -R `whoami` ./
                       git config --global --add safe.directory '*'


### PR DESCRIPTION
This PR adds build steps for node 20.

It also contains the followin changes:

1. Splits the macos and windows builds since the MAC build didn't like the `npm config set msvs_version "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise" --global` argument into npm.

2. Removes the "invalid"? npm config command `npm config set spin false` which no longer is supported in newer NPM versions.

3. Adds builds steps arm64 macos