### PR TITLE
Fix ci darwin arm64

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -49,48 +49,6 @@ jobs:
               with:
                   asset_paths: '["./build/stage/libxmljs/libxmljs/releases/download/**/*.tar.gz"]'
 
-    upload-macos-arm64:
-        strategy:
-            fail-fast: false
-            matrix:
-                config:
-                    - { node-version: 8, npm-version: 6 }
-                    - { node-version: 9, npm-version: 6 }
-                    - { node-version: 10, npm-version: 6 }
-                    - { node-version: 11, npm-version: 6 }
-                    - { node-version: 12, npm-version: 8 }
-                    - { node-version: 13, npm-version: 8 }
-                    - { node-version: 14, npm-version: 8 }
-                    - { node-version: 15, npm-version: 8 }
-                    - { node-version: 16, npm-version: 8 }
-                    - { node-version: 17, npm-version: 8 }
-                    - { node-version: 18, npm-version: 8 }
-                    - { node-version: 20, npm-version: 10 }
-        runs-on: macos-latest
-        steps:
-            - uses: actions/checkout@master
-              with:
-                  fetch-depth: 1
-            - uses: actions/setup-node@v2
-              with:
-                  node-version: ${{ matrix.config.node-version }}
-                  registry-url: https://registry.npmjs.org
-
-            - name: Package prebuilt binary
-              run: |
-                  npm install -g npm@${{ matrix.config.npm-version }}
-                  npm config set progress false
-                  npm install --build-from-source
-                  npm run package -- --target_arch=arm64 --target_platform=darwin 2>&1
-                  npm run tsc
-                  npm run test
-            - name: Upload release binary
-              uses: alexellis/upload-assets@0.3.0
-              env:
-                  GITHUB_TOKEN: ${{ github.token }}
-              with:
-                  asset_paths: '["./build/stage/libxmljs/libxmljs/releases/download/**/*.tar.gz"]'
-
     upload-windows:
         strategy:
             fail-fast: false

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
   },
   "description": "libxml bindings for v8 javascript engine",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "repository": {
     "type": "git",
     "url": "http://github.com/libxmljs/libxmljs.git"


### PR DESCRIPTION
Hi @rchipka @anderssonoscar0 

this PR in order to fix https://github.com/libxmljs/libxmljs/issues/637 (basically removed darwin arm64 build)

Today the crossbuild darwin x64_86 -> arm64 seems not to be supported on standard x86_64 macos runners, thus the supposed arm64 artefact (https://github.com/libxmljs/libxmljs/releases/download/v1.0.10/node-v115-darwin-arm64.tar.gz) contains a x86_64 file, and this one is not usable on a M1/M2 cpu.

An option would be to use a recently released github silicon worker (https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/) but they are not available for free by contrast to standard macos runners.

That's why I suggest to remove this build for now.


