### PR TITLE
Validate multiple doc without rebuilding schema

### DIFF
--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -16,6 +16,10 @@ jobs:
                     - { os: windows-2019, arch: x64 }
         steps:
             - uses: actions/checkout@v3
+            - name: Force Python 3.10 (newer versions do not work with node-gyp version bundled with node v12)
+              uses: actions/setup-python@v2
+              with:
+                python-version: '3.10'
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v3
               with:

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,7 +2,7 @@
 
 import { HTMLDocument, XMLDocument } from "./document";
 import { XMLElement, XMLText, XMLNamespace, XMLNodeError, XMLNode } from "./node";
-import { parseHtml, parseHtmlAsync, parseXml, parseXmlAsync } from "./parse";
+import { parseHtml, parseHtmlAsync, parseXml, parseXmlAsync, parseSchema } from "./parse";
 import { SaxParser, SaxPushParser } from "./sax";
 import { HTMLParseOptions, XMLParseOptions } from "./types";
 
@@ -93,6 +93,7 @@ export {
     parseXmlAsync,
     parseHtml,
     parseHtmlAsync,
+    parseSchema,
     SaxParser,
     SaxPushParser
 };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,6 @@
 export { XMLDocument, HTMLDocument } from "./document";
 export { XMLNode, XMLElement, XMLAttribute, XMLNamespace } from "./node";
+export { XMLSchema } from "./schema";
 
 export * from "./api";
 export * from "./types";

--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -23,6 +23,7 @@ import {
 } from "./bindings/functions";
 
 import { HTMLDocument, XMLDocument } from "./document";
+import { XMLSchema } from "./schema";
 import { XMLNodeError } from "./node";
 
 const htmlOptionsToFlags = (options: HTMLParseOptions): number => {
@@ -265,6 +266,12 @@ export const parseXml = (buffer: string | Buffer, options: XMLParseOptions = DEF
 
         return document;
     });
+
+export const parseSchema = (buffer: string | Buffer, options: XMLParseOptions = DEFAULT_XML_PARSE_OPTIONS): XMLSchema => {
+    const document = parseXml(buffer, options);
+    const schema = XMLSchema._parseSchema(document);
+    return schema;
+}
 
 export const parseHtml = (buffer: string | Buffer, options: HTMLParseOptions = {}): HTMLDocument =>
     withStructuredErrors((structuredErrors) => {

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -1,0 +1,84 @@
+import { XMLReference, createXMLReferenceOrThrow } from "./bindings";
+
+import {
+    withStructuredErrors,
+    xmlResetLastError,
+    xmlSchemaFreeParserCtxt,
+    xmlSchemaFreeValidCtxt,
+    xmlSchemaNewDocParserCtxt,
+    xmlSchemaNewValidCtxt,
+    xmlSchemaParse,
+    xmlSchemaValidateDoc
+} from "./bindings/functions";
+
+import { xmlSchemaPtr } from "./bindings/types";
+
+import { XMLDocument } from './document'
+
+import { XMLDocumentError, XMLStructuredError } from "./types";
+
+export class XMLSchema extends XMLReference<xmlSchemaPtr> {
+    public errors: XMLStructuredError[];
+    public validationErrors: any[];
+
+    /**
+     * @private
+     * @param _ref
+     */
+    constructor(_ref: any) {
+        super(_ref);
+
+        this.errors = [];
+        this.validationErrors = [];
+    }
+
+    /**
+     * @private
+     * @param schemaDoc
+     */
+    public static _parseSchema(schemaDoc: XMLDocument): XMLSchema {
+        xmlResetLastError();
+
+        return withStructuredErrors((errors) => {
+            const _schemaDocRef = schemaDoc._getDocReference();
+
+            const parser_ctxt = xmlSchemaNewDocParserCtxt(_schemaDocRef);
+            if (parser_ctxt === null) {
+                throw new Error("Could not create context for schema parser");
+            }
+
+            const _schemaRef = xmlSchemaParse(parser_ctxt);
+            if (_schemaRef === null) {
+                throw new Error("Invalid XSD schema");
+            }
+
+            xmlSchemaFreeParserCtxt(parser_ctxt);
+
+            const schema = createXMLReferenceOrThrow(XMLSchema, _schemaRef, XMLDocumentError.NO_REF);
+            schema.validationErrors = errors;
+
+            return schema
+        })
+    }
+
+    validateDocument(doc: XMLDocument) {
+        xmlResetLastError();
+
+        return withStructuredErrors((errors) => {
+            const _docRef = doc._getDocReference();
+
+            const valid_ctxt = xmlSchemaNewValidCtxt(this.getNativeReference());
+            if (valid_ctxt === null) {
+                throw new Error("Unable to create a validation context for the schema");
+            }
+
+            const valid = xmlSchemaValidateDoc(valid_ctxt, _docRef) == 0;
+
+            xmlSchemaFreeValidCtxt(valid_ctxt);
+
+            doc.validationErrors = errors;
+
+            return valid
+        })
+    }
+}


### PR DESCRIPTION
Proposal for #628.

The goal is to provide a way to validate multiples docs without parsing again the schema.

```typescript
import libxmljs from "libxmljs";

const xsd = '<?xml version="1.0" encoding="UTF-8"?>...'

// Parse schema and build context
const schema = libxmljs.parseSchema(xsd)

// Validate all docs
schema.validateDocument(xmlDoc1)
schema.validateDocument(xmlDoc2)
schema.validateDocument(xmlDoc3)

// Still working
xmlDoc1.validate(xsd)
```