### PR TITLE
In case of invalid XSD, show error messages

### DIFF
--- a/lib/document.ts
+++ b/lib/document.ts
@@ -261,20 +261,20 @@ export class XMLDocument extends XMLReference<xmlDocPtr> {
             const parser_ctxt = xmlSchemaNewDocParserCtxt(schemaDoc.getNativeReference());
 
             if (parser_ctxt === null) {
-                throw new Error("Could not create context for schema parser");
+                throw new Error("Could not create context for schema parser: " + errors.map(function (e) { return e.message; }).join(", "));
             }
 
             const schema = xmlSchemaParse(parser_ctxt);
 
 
             if (schema === null) {
-                throw new Error("Invalid XSD schema");
+                throw new Error("Invalid XSD schema: " + errors.map(function (e) { return e.message; }).join(", "));
             }
 
             const valid_ctxt = xmlSchemaNewValidCtxt(schema);
 
             if (valid_ctxt === null) {
-                throw new Error("Unable to create a validation context for the schema");
+                throw new Error("Unable to create a validation context for the schema: " + errors.map(function (e) { return e.message; }).join(", "));
             }
 
             const valid =


### PR DESCRIPTION
If the XSD is invalid, all the user sees right now is 
```
  Error: Invalid XSD schema
      at ./node_modules/libxmljs/dist/lib/document.js:183:23
      at XMLDocument.validate (./node_modules/libxmljs/dist/lib/document.js:176:53)
      at validateSchema (./node_modules/xsd-validator/index.js:8:22)
```

With this change, the user sees e.g.:
```
  Error: Invalid XSD schema: Element '{http://www.w3.org/2001/XMLSchema}pattern': The value '\\d{1,4}[a-zA-Z]?(\\/\\d{1,4})?(-\\d{1,4})?' of the facet 'pattern' is not a valid regular expression.
      at ./node_modules/libxmljs/dist/lib/document.js:183:23
      at XMLDocument.validate (./node_modules/libxmljs/dist/lib/document.js:176:53)
      at validateSchema (./node_modules/xsd-validator/index.js:8:22)
```