### PR TITLE
fix: make parseXMLAsync and parseXML have the same defaults for encoding

### DIFF
--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -229,7 +229,7 @@ export const parseXml = (buffer: string | Buffer, options: XMLParseOptions = DEF
             buffer,
             typeof buffer === "string" ? Buffer.byteLength(buffer) : buffer.length,
             options.baseUrl || DEFAULT_XML_PARSE_OPTIONS.baseUrl || "",
-            options.encoding || (typeof buffer === "string" ? "UTF-8" : null),
+            options.encoding || DEFAULT_XML_PARSE_OPTIONS.encoding || (typeof buffer === "string" ? "UTF-8" : null),
             xmlOptionsToFlags(options)
         );
 
@@ -317,7 +317,7 @@ export const parseXmlAsync = async (
         buffer,
         typeof buffer === "string" ? Buffer.byteLength(buffer) : buffer.length,
         options.url || DEFAULT_XML_PARSE_OPTIONS.url || "",
-        options.encoding || DEFAULT_XML_PARSE_OPTIONS.encoding || "",
+        options.encoding || DEFAULT_XML_PARSE_OPTIONS.encoding || (typeof buffer === "string" ? "UTF-8" : ""),
         xmlOptionsToFlags(options),
         (error: Error | null, document: xmlDocPtr | null) => {
             if (error) {

--- a/test/xml_parser.ts
+++ b/test/xml_parser.ts
@@ -21,6 +21,20 @@ module.exports.parse = function (assert: any) {
     assert.done();
 };
 
+module.exports.parseWithInvisibleCharacter = function (assert: any) {
+    var strWithInvisibleCharacter = "\uFEFF<?xml version=\"1.0\" encoding=\"UTF-8\"?><root><child>with love</child><sibling>with content!</sibling></root>";
+    
+    var doc = libxml.parseXml(strWithInvisibleCharacter)
+    assert.equal("1.0", doc.version());
+    assert.equal("UTF-8", doc.encoding());
+    assert.equal("root", doc.root()?.name());
+    assert.equal("child", (doc.get("child") as XMLElement).name());
+    assert.equal("with love", (doc.get("child") as XMLElement).text());
+    assert.equal("sibling", (doc.get("sibling") as XMLElement).name());
+    assert.equal("with content!", (doc.get("sibling") as XMLElement).text());
+    assert.done();
+}
+
 module.exports.parse_with_flags = function (assert: any) {
     const filename = __dirname + "/../../test/fixtures/parser.xml";
     const str = fs.readFileSync(filename, "utf8").replace(/[\r]+/g, '');
@@ -54,6 +68,26 @@ module.exports.parseAsync = function (assert: any) {
 
     assert.equal(++x, 1);
 };
+
+
+module.exports.parseAsyncWithInvisibleCharacter = function (assert: any) {
+    var strWithInvisibleCharacter = "\uFEFF<?xml version=\"1.0\" encoding=\"UTF-8\"?><root><child>with love</child><sibling>with content!</sibling></root>";
+
+    let x = 0;
+    
+    libxml.parseXmlAsync(strWithInvisibleCharacter).then((doc) => {
+        assert.equal(++x, 2);
+        assert.equal("1.0", doc.version());
+        assert.equal("UTF-8", doc.encoding());
+        assert.equal("root", doc.root()?.name());
+        assert.equal("child", (doc.get("child") as XMLElement).name());
+        assert.equal("with love", (doc.get("child") as XMLElement).text());
+        assert.equal("sibling", (doc.get("sibling") as XMLElement).name());
+        assert.equal("with content!", (doc.get("sibling") as XMLElement).text());
+        assert.done();
+    });
+    assert.equal(++x, 1);
+}
 
 module.exports.parse_async_with_replace = function (assert: any) {
     const filename = __dirname + "/../../test/fixtures/parser.xml";


### PR DESCRIPTION
# Context

We're currently using `libxmljs` to parse XML for SAML IDP metadata. When we fetch the metadata from the service, the `response.body` may sometimes come back as a string with the following invisible first character: `\uFEFF`.

This character is the Unicode Byte Order Mark (BOM). It’s a special invisible character that's often used at the beginning of text files to indicate the byte order (endianness) of the file, and it is particularly common for UTF-8 encoded files.

I noticed that the behavior between `libxmljs.parseXml` and `libxmljs.parseXmlAsync` handled this invisible character differently. 

`libxmljs.parseXml` succeeds with no issue because if the `buffer` is a `string`, it will default to an encoding of `UTF-8`.

However, `libxmljs.parseXmlAsync` fails because it only uses `DEFAULT_XML_PARSE_OPTIONS.encoding`. This is not defined, which then it throws with the following error: `Error: Start tag expected, '<' not found`.

# The Change
`libxmljs.parseXml` and `libxmljs.parseXmlAsync` both now have the following as its encoding argument: `options.encoding || DEFAULT_XML_PARSE_OPTIONS.encoding || (typeof buffer === "string" ? "UTF-8" : null),` which should handle this invisible character case.
 